### PR TITLE
Make pipeline loading more compatible with older versions

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -451,22 +451,13 @@ class Pipeline:
                     if len(line.split(":", 1)) != 2:
                         raise ValueError("Invalid format for setting: %s" % line)
                     text, setting = line.split(":", 1)
-                    setting = setting.encode("utf-8").decode("unicode_escape")
-                    # TODO: remove en/decode when example cppipe no longer has \x__ characters
-                    # En/decode needed to read example cppipe format
-                    # setting = (
-                    #     setting.encode().decode("unicode_escape").replace("\\\\", "\\")
-                    # )
-                    #
-                    # if do_deprecated_utf16_decode:
-                    #     # decoding with 'unicode_escape' appears to be sufficient
-                    #     pass
-                    # elif do_utf16_decode:
-                    #     # Real hack-y way to do utf-16 decoding; was read as str so can't .decode('utf-16')
-                    #     setting = "".join(
-                    #         filter(lambda x: x in string.printable, setting)
-                    #     )
-
+                    if "\\x" in setting:
+                        try:
+                            setting = setting.encode("utf-8").decode("unicode_escape")
+                        except UnicodeDecodeError as e:
+                            setting = setting.encode("utf-8").decode("utf-8")
+                    if len(setting) > 1:
+                        setting = setting.replace("\x00", "").strip("ÿþ")
                     settings.append(setting)
 
                 module = self.setup_module(


### PR DESCRIPTION
Should fix CellProfiler/CellProfiler#4036.

Aside from Unicode errors, a key problem fixing this has been the decoding process removing backslashes which were part of pathnames and regex conditions. The solution I have for now isn't 100% robust (you could still mess up a setting that contained '\x'), but hopefully it's a start. 3.0.0 pipelines appear to sometimes contain characters like '\x5B' and '\x3A' so just looking for '\xff' wasn't too effective. If someone knows which possible characters to search for we might be able to just check against a more defined list to determine whether a setting needs decoding.