### PR TITLE
Fix helptext image imports

### DIFF
--- a/cellprofiler_core/module/__init__.py
+++ b/cellprofiler_core/module/__init__.py
@@ -5,6 +5,7 @@ from cellprofiler_core.module.image_segmentation import (
     ImageSegmentation,
 )
 from cellprofiler_core.module._image_processing import ImageProcessing
+import cellprofiler_core.utilities
 
 
 DEFINITION_OBJECT = """\
@@ -90,7 +91,7 @@ conditions you want to include.
 {REGEXP_HELP_REF}
 """.format(
     **{
-        "IMAGES_USING_RULES_ICON": cellprofiler_core.preferences.image_resource(
+        "IMAGES_USING_RULES_ICON": cellprofiler_core.utilities.image_resource(
             "Images_UsingRules.png"
         ),
         "REGEXP_HELP_REF": REGEXP_HELP_REF,
@@ -223,7 +224,7 @@ overlay outlines or objects, respectively, on a base image.
 The resulting image can also be saved with the **SaveImages** module.
 """
 
-StrelImage = cellprofiler_core.preferences.image_resource("structuringelement.png")
+StrelImage = cellprofiler_core.utilities.image_resource("structuringelement.png")
 
 HELP_FOR_STREL = """\
 The structuring element is the shape that will be applied in any morphological
@@ -239,8 +240,8 @@ pixel diameter with various structuring elements.
     **{"StrelImage": StrelImage}
 )
 
-PROTIP_RECOMMEND_ICON = cellprofiler_core.preferences.image_resource("thumb-up.png")
+PROTIP_RECOMMEND_ICON = cellprofiler_core.utilities.image_resource("thumb-up.png")
 
-PROTIP_AVOID_ICON = cellprofiler_core.preferences.image_resource("thumb-down.png")
+PROTIP_AVOID_ICON = cellprofiler_core.utilities.image_resource("thumb-down.png")
 
-TECH_NOTE_ICON = cellprofiler_core.preferences.image_resource("gear.png")
+TECH_NOTE_ICON = cellprofiler_core.utilities.image_resource("gear.png")

--- a/cellprofiler_core/modules/groups.py
+++ b/cellprofiler_core/modules/groups.py
@@ -12,6 +12,7 @@ import cellprofiler_core.pipeline
 import cellprofiler_core.setting
 import cellprofiler_core.setting
 import cellprofiler_core.measurement
+import cellprofiler_core.utilities
 
 __doc__ = """\
 Groups

--- a/cellprofiler_core/preferences/__init__.py
+++ b/cellprofiler_core/preferences/__init__.py
@@ -22,6 +22,7 @@ import weakref
 import pkg_resources
 
 import cellprofiler_core.utilities.utf16encode
+import cellprofiler_core.utilities
 
 logger = logging.getLogger(__name__)
 
@@ -33,24 +34,6 @@ ABSPATH_IMAGE = "abspath_image"
 
 __python_root = os.path.split(str(cellprofiler_core.__path__[0]))[0]
 __cp_root = os.path.split(__python_root)[0]
-
-
-def image_resource(filename):
-    relpath = os.path.relpath(
-        pkg_resources.resource_filename(
-            "cellprofiler_core", os.path.join("data", "images", filename)
-        )
-    )
-
-    # With this specific relative path we are probably building the documentation
-    # in sphinx The path separator used by sphinx is "/" on all platforms.
-    if relpath == os.path.join("..", "cellprofiler_core", "data", "images", filename):
-        return "../images/{}".format(filename)
-
-    # Otherwise, if you're rendering in the GUI, relative paths are fine
-    # Note: the HTML renderer requires to paths to use '/' so we replace
-    # the windows default '\\' here
-    return relpath.replace("\\", "/")
 
 
 class HeadlessConfig:
@@ -485,8 +468,12 @@ created according to the pathname you have typed.
 .. |image1| image:: {CREATE_BUTTON}\
 """.format(
     **{
-        "CREATE_BUTTON": image_resource("folder_create.png"),
-        "BROWSE_BUTTON": image_resource("folder_browse.png"),
+        "CREATE_BUTTON": cellprofiler_core.utilities.image_resource(
+            "folder_create.png"
+        ),
+        "BROWSE_BUTTON": cellprofiler_core.utilities.image_resource(
+            "folder_browse.png"
+        ),
     }
 )
 

--- a/cellprofiler_core/utilities/__init__.py
+++ b/cellprofiler_core/utilities/__init__.py
@@ -6,21 +6,18 @@ import pkg_resources
 
 
 def image_resource(filename):
-    relpath = os.path.relpath(
-        pkg_resources.resource_filename(
-            "cellprofiler_core", os.path.join("data", "images", filename)
+    try:
+        abspath = os.path.abspath(
+            pkg_resources.resource_filename(
+                "cellprofiler", os.path.join("data", "images", filename)
+            )
         )
-    )
-
-    # With this specific relative path we are probably building the documentation
-    # in sphinx The path separator used by sphinx is "/" on all platforms.
-    if relpath == os.path.join("..", "cellprofiler_core", "data", "images", filename):
-        return "../images/{}".format(filename)
-
-    # Otherwise, if you're rendering in the GUI, relative paths are fine
-    # Note: the HTML renderer requires to paths to use '/' so we replace
-    # the windows default '\\' here
-    return relpath.replace("\\", "/")
+        return abspath.replace("\\", "/")
+    except ModuleNotFoundError:
+        # CellProfiler is not installed so the assets are missing.
+        # In theory an icon should never be called without the GUI anyway
+        print("CellProfiler image assets were not found")
+    return ""
 
 
 def generate_presigned_url(url):


### PR DESCRIPTION
Help dialogs for core's builtin modules currently need images from CellProfiler's data/images folder. It's not an optimal solution, but for now I've made core fetch these images from the proper directory if CellProfiler is installed. In theory said images should never be needed or displayed without the GUI, so I don't think this will cause any problems. An alternative would be to move those specific images to somewhere in core, although some are used in both core and CellProfiler itself.

I've also removed the duplicated image_resource function. It was copied into both `preferences` in `utilities`, but now lives in `utilities`.