### PR TITLE
Fix pipeline load errors with certain attribute strings

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -500,6 +500,8 @@ class Pipeline:
             or attribute_string[-1] != "]"
         ):
             raise ValueError("Invalid format for attributes: %s" % attribute_string)
+        # Fix for array dtypes which contain split separator
+        attribute_string = attribute_string.replace("dtype='|S", "dtype='S")
         attribute_strings = attribute_string[1:-1].split("|")
         variable_revision_number = None
         # make batch_state decodable from text pipelines
@@ -512,7 +514,6 @@ class Pipeline:
             if len(a.split(":", 1)) != 2:
                 raise ValueError("Invalid attribute string: %s" % a)
             attribute, value = a.split(":", 1)
-            # FIXME: This is naughty
             value = eval(value)
             if attribute in skip_attributes:
                 continue


### PR DESCRIPTION
It turns out that numpy arrays can have the data types `|S1` and `|S2`. This was causing problems with pipeline loading from CP3 since `|` is used to split module attributes. Numpy automatically treats `S1` as `|S1` so I think this should fix the issue.