### PR TITLE
Fix Groups tables not updating when a key is first selected

### DIFF
--- a/cellprofiler_core/modules/groups.py
+++ b/cellprofiler_core/modules/groups.py
@@ -366,8 +366,6 @@ desired behavior.
     def visible_settings(self):
         result = [self.wants_groups]
         if self.wants_groups:
-            if self.metadata_keys and len(self.metadata_keys) > 0:
-                self.update_tables()
             for group in self.grouping_metadata:
                 result += [group.metadata_choice]
                 if group.can_remove:
@@ -632,8 +630,15 @@ desired behavior.
         if not self.wants_groups:
             return True
 
+        for group in self.grouping_metadata:
+            if group.metadata_choice.value == "None":
+                return False
+
         if len(workspace.measurements.get_image_numbers()) == 0:
-            return False
+            # Refresh image set to make sure it's actually empty
+            workspace.refresh_image_set()
+            if len(workspace.measurements.get_image_numbers()) == 0:
+                return False
 
         result = self.get_groupings(workspace)
         if result is None:

--- a/cellprofiler_core/modules/groups.py
+++ b/cellprofiler_core/modules/groups.py
@@ -364,9 +364,10 @@ desired behavior.
         return result
 
     def visible_settings(self):
-        self.update_tables()
         result = [self.wants_groups]
         if self.wants_groups:
+            if self.metadata_keys and len(self.metadata_keys) > 0:
+                self.update_tables()
             for group in self.grouping_metadata:
                 result += [group.metadata_choice]
                 if group.can_remove:

--- a/cellprofiler_core/modules/groups.py
+++ b/cellprofiler_core/modules/groups.py
@@ -364,6 +364,7 @@ desired behavior.
         return result
 
     def visible_settings(self):
+        self.update_tables()
         result = [self.wants_groups]
         if self.wants_groups:
             for group in self.grouping_metadata:


### PR DESCRIPTION
Even in 3.1.9, selecting a metadata category in the 'Groups' module would fail to display anything in the module's tables until the user leaves/returns to the module. Looks like the problem is that the refresh function fetches `visible_settings` to perform the update, which still contains the empty tables until the module is activated again.

I think the fix for this is running `update_tables` prior to fetching the visible settings. I've added that and it seems to work.