### PR TITLE
Refine plugin list behaviour

### DIFF
--- a/cellprofiler_core/utilities/core/modules/__init__.py
+++ b/cellprofiler_core/utilities/core/modules/__init__.py
@@ -23,12 +23,8 @@ from ....constants.modules import (
 
 def plugin_list(plugin_dir):
     if plugin_dir is not None and os.path.isdir(plugin_dir):
-        file_list = glob.glob(os.path.join(plugin_dir, "*.py"))
-        return [
-            os.path.basename(f)[:-3]
-            for f in file_list
-            if not f.endswith(("__init__.py", "_help.py"))
-        ]
+        file_list = glob.glob(os.path.join(plugin_dir, "[!_]*.py"))
+        return [os.path.basename(f)[:-3] for f in file_list]
     return []
 
 


### PR DESCRIPTION
I was looking at CellProfiler/CellProfiler#3773 and wondered if this might be helpful? Currently we scan the plugins directory and try to load anything that's not titled `__init__.py` or `_help.py`. This PR would make it so that any filename starting with `_` is ignored, which I imagine might allow people to add helper scripts without CellProfiler attempting to load them as actual modules. This also eliminates the need to check the names within the list comprehension.