### PR TITLE
Fix escaping when setting directory using FileName settings

### DIFF
--- a/cellprofiler_core/setting/text/_directory.py
+++ b/cellprofiler_core/setting/text/_directory.py
@@ -61,6 +61,8 @@ class Directory(Text):
 
     def join_parts(self, dir_choice=None, custom_path=None):
         """Join the directory choice and custom path to form a value"""
+        if custom_path is not None:
+            custom_path = custom_path.replace("\\", "\\\\")
         self.value = self.join_string(dir_choice, custom_path)
 
     def join_string(self, dir_choice=None, custom_path=None):


### PR DESCRIPTION
I found a bug in some module settings. In modules prompting for a file, such as FilterObjects using a rules file, browsing for a file should update both the filename and directory fields. The directory field was fine when set using it's own widget, but when updated by choosing the filename instead the directory field text wasn't being escaped. Internally the setting itself was fine, but the settings panel display would show "pathtofile" instead of "path/to/file". I believe this PR should fix that by escaping the custom path strings.