### PR TITLE
Better escaping of directories?

### DIFF
--- a/cellprofiler_core/setting/text/_directory.py
+++ b/cellprofiler_core/setting/text/_directory.py
@@ -61,7 +61,7 @@ class Directory(Text):
 
     def join_parts(self, dir_choice=None, custom_path=None):
         """Join the directory choice and custom path to form a value"""
-        if custom_path is not None:
+        if custom_path is not None and "\\\\" not in custom_path:
             custom_path = custom_path.replace("\\", "\\\\")
         self.value = self.join_string(dir_choice, custom_path)
 


### PR DESCRIPTION
This might help with the pipeline decoding issues. Some older formats are already escaped, but others aren't.