### PR TITLE
Make execution time a float

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -44,6 +44,7 @@ from .event import PrepareRunException
 from .event import RunException
 from .event import URLsAdded
 from .event import URLsRemoved
+from ..constants.measurement import COLTYPE_FLOAT
 from ..constants.measurement import COLTYPE_INTEGER
 from ..constants.measurement import COLTYPE_LONGBLOB
 from ..constants.measurement import COLTYPE_VARCHAR
@@ -1018,7 +1019,7 @@ class Pipeline:
                         measurements.add_measurement(
                             "Image",
                             execution_time_measurement,
-                            numpy.array([cpu_delta_sec]),
+                            numpy.array([float(cpu_delta_sec)]),
                         )
 
                     while (
@@ -1173,7 +1174,7 @@ class Pipeline:
                 measurements[
                     "Image",
                     "ExecutionTime_%02d%s" % (module.module_num, module.module_name),
-                ] = cpu_delta_secs
+                ] = float(cpu_delta_secs)
 
             measurements.flush()
             if workspace.disposition == DISPOSITION_SKIP:
@@ -2330,7 +2331,7 @@ class Pipeline:
                 )
                 columns += [
                     ("Image", module_error_measurement, COLTYPE_INTEGER,),
-                    ("Image", execution_time_measurement, COLTYPE_INTEGER,),
+                    ("Image", execution_time_measurement, COLTYPE_FLOAT,),
                 ]
         self.__measurement_columns[terminating_module_num] = columns
         return columns

--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -44,7 +44,7 @@ from .event import PrepareRunException
 from .event import RunException
 from .event import URLsAdded
 from .event import URLsRemoved
-from ..constants.measurement import COLTYPE_INTEGER, COLTYPE_FLOAT
+from ..constants.measurement import COLTYPE_INTEGER
 from ..constants.measurement import COLTYPE_LONGBLOB
 from ..constants.measurement import COLTYPE_VARCHAR
 from ..constants.measurement import C_FRAME
@@ -1267,7 +1267,7 @@ class Pipeline:
             M_VERSION, __version__,
         )
         m.add_experiment_measurement(
-            M_TIMESTAMP, float(datetime.datetime.now().timestamp()),
+            M_TIMESTAMP, datetime.datetime.now().isoformat(),
         )
         m.flush()
 
@@ -1452,7 +1452,7 @@ class Pipeline:
                         exc_info=True,
                     )
         workspace.measurements.add_experiment_measurement(
-            M_MODIFICATION_TIMESTAMP, float(datetime.datetime.now().timestamp()),
+            M_MODIFICATION_TIMESTAMP, datetime.datetime.now().isoformat(),
         )
 
         return "Complete"
@@ -2299,11 +2299,11 @@ class Pipeline:
         columns = [
             (EXPERIMENT, M_PIPELINE, COLTYPE_LONGBLOB,),
             (EXPERIMENT, M_VERSION, COLTYPE_VARCHAR,),
-            (EXPERIMENT, M_TIMESTAMP, COLTYPE_FLOAT,),
+            (EXPERIMENT, M_TIMESTAMP, COLTYPE_VARCHAR,),
             (
                 EXPERIMENT,
                 M_MODIFICATION_TIMESTAMP,
-                COLTYPE_FLOAT,
+                COLTYPE_VARCHAR,
                 {MCA_AVAILABLE_POST_RUN: True},
             ),
             ("Image", GROUP_NUMBER, COLTYPE_INTEGER,),


### PR DESCRIPTION
Reverts previous change which impacted timestamps, not execution times. Fixes CellProfiler/CellProfiler#3884