### PR TITLE
Allow loading of 3D object sets

### DIFF
--- a/cellprofiler_core/modules/namesandtypes.py
+++ b/cellprofiler_core/modules/namesandtypes.py
@@ -14,6 +14,8 @@ from ..constants.image import C_SCALING
 from ..constants.image import C_SERIES
 from ..constants.image import C_WIDTH
 from ..constants.measurement import COLTYPE_FLOAT
+from ..constants.measurement import FTR_CENTER_Z
+from ..constants.measurement import M_LOCATION_CENTER_Z
 from ..constants.measurement import COLTYPE_INTEGER
 from ..constants.measurement import COLTYPE_VARCHAR
 from ..constants.measurement import COLTYPE_VARCHAR_FILE_NAME
@@ -2123,14 +2125,29 @@ requests an object selection.
                 url = ipds[0].url
 
         url = workspace.measurements.alter_url_post_create_batch(url)
-        provider = ObjectsImage(name, url, series, index)
+        volume = self.process_as_3d.value
+        spacing = (self.z.value, self.x.value, self.y.value) if volume else None
+        provider = ObjectsImage(
+            name, url, series, index, volume=volume, spacing=spacing
+        )
         self.add_provider_measurements(
             provider, workspace.measurements, "Object",
         )
         image = provider.provide_image(workspace.image_set)
         o = Objects()
-        if image.pixel_data.shape[2] == 1:
+        shape = image.pixel_data.shape
+        if shape[2] == 1:
             o.segmented = image.pixel_data[:, :, 0]
+            add_object_location_measurements(
+                workspace.measurements, name, o.segmented, o.count
+            )
+        elif volume:
+            if len(shape) == 3:
+                o.segmented = image.pixel_data
+            elif len(shape) == 4 and shape[-1] == 1:
+                o.segmented = image.pixel_data[:, :, :, 0]
+            else:
+                raise NotImplementedError("ijv volumes not yet supported")
             add_object_location_measurements(
                 workspace.measurements, name, o.segmented, o.count
             )
@@ -2245,10 +2262,11 @@ requests an object selection.
                 )
             ]
             result += get_object_measurement_columns(object_name)
+            if self.process_as_3d.value:
+                result += ((object_name, M_LOCATION_CENTER_Z, COLTYPE_FLOAT,),)
         result += [
             ("Image", ftr, COLTYPE_VARCHAR,) for ftr in self.get_metadata_features()
         ]
-
         return result
 
     def get_categories(self, pipeline, object_name):
@@ -2307,10 +2325,13 @@ requests an object selection.
             if category == C_NUMBER:
                 return [FTR_OBJECT_NUMBER]
             elif category == C_LOCATION:
-                return [
+                result = [
                     FTR_CENTER_X,
                     FTR_CENTER_Y,
                 ]
+                if self.process_as_3d.value:
+                    result += [FTR_CENTER_Z]
+                return result
         return []
 
     def validate_module(self, pipeline):

--- a/cellprofiler_core/utilities/core/module/identify.py
+++ b/cellprofiler_core/utilities/core/module/identify.py
@@ -9,6 +9,7 @@ from cellprofiler_core.constants.measurement import (
     COLTYPE_FLOAT,
     COLTYPE_INTEGER,
     IMAGE,
+    M_LOCATION_CENTER_Z,
 )
 
 
@@ -34,11 +35,18 @@ def add_object_location_measurements(
             numpy.ones(labels.shape), labels, list(range(1, object_count + 1))
         )
         centers = numpy.array(centers)
-        centers = centers.reshape((object_count, 2))
-        location_center_y = centers[:, 0]
-        location_center_x = centers[:, 1]
+        centers = centers.reshape((object_count, len(labels.shape)))
+        vol = centers.shape[1] == 3
+        if not vol:
+            location_center_y = centers[:, 0]
+            location_center_x = centers[:, 1]
+        else:
+            location_center_z = centers[:, 0]
+            location_center_y = centers[:, 1]
+            location_center_x = centers[:, 2]
         number = numpy.arange(1, object_count + 1)
     else:
+        location_center_z = numpy.zeros((0,), dtype=float)
         location_center_y = numpy.zeros((0,), dtype=float)
         location_center_x = numpy.zeros((0,), dtype=float)
         number = numpy.zeros((0,), dtype=int)
@@ -48,6 +56,11 @@ def add_object_location_measurements(
     measurements.add_measurement(
         object_name, M_LOCATION_CENTER_Y, location_center_y,
     )
+    if vol:
+        measurements.add_measurement(
+            object_name, M_LOCATION_CENTER_Z, location_center_z,
+        )
+
     measurements.add_measurement(
         object_name, M_NUMBER_OBJECT_NUMBER, number,
     )


### PR DESCRIPTION
Fixes CellProfiler/CellProfiler#3523

This one was a bit painful. For some reason prokaryote seems to fail to return the correct number of planes when told to load objects, and that plane information was needed by the Bioformats importer. For now I've had it instead load in the image with imageio and work from that, which is faster anyway.