### PR TITLE
Fix module notes loading

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -551,7 +551,11 @@ class Pipeline:
         array = numpy.array
         uint8 = numpy.uint8
         for a in attribute_strings:
-            a = a.encode("utf-8").decode("unicode_escape")
+            if a.isascii():
+                a = a.encode("utf-8").decode("unicode_escape")
+            else:
+                # We're in unicode already, remove escapes
+                a = a.replace("\\", "")
             if len(a.split(":", 1)) != 2:
                 raise ValueError("Invalid attribute string: %s" % a)
             attribute, value = a.split(":", 1)

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -706,10 +706,17 @@ HasImagePlaneDetails:False"""
         assert len(pipeline.modules()) == 1
         result_module = pipeline.modules()[0]
         assert isinstance(result_module, MeasurementFixture,)
-        assert module.notes == eval(result_module.notes)
+        assert module.notes == result_module.notes
         assert module.my_variable.value == result_module.my_variable.value
 
     def test_deprecated_unicode_load(self):
+        import cellprofiler_core.constants.modules
+        from cellprofiler_core.utilities.core.modules import fill_modules
+
+        cellprofiler_core.constants.modules.builtin_modules[
+            "measurementfixture"
+        ] = "MeasurementFixture"
+        fill_modules()
         pipeline = get_empty_pipeline()
         deprecated_pipeline_file = os.path.realpath(
             os.path.join(os.path.dirname(__file__), "../data/pipeline/v3.cppipe")
@@ -718,7 +725,7 @@ HasImagePlaneDetails:False"""
         module = MeasurementFixture()
         module.my_variable.value = "∑"
         module.set_module_num(1)
-        module.notes = "\\'αβ\\'"
+        module.notes = "αβ"
         assert len(pipeline.modules()) == 1
         result_module = pipeline.modules()[0]
         assert isinstance(result_module, MeasurementFixture,)


### PR DESCRIPTION
This should hopefully handle loading pipelines with unicode characters in the module notes text. Trying to decode those completely messes up the characters.