### PR TITLE
Fix pipeline sanitization

### DIFF
--- a/cellprofiler_core/pipeline/io/_v5.py
+++ b/cellprofiler_core/pipeline/io/_v5.py
@@ -48,8 +48,9 @@ def dump(pipeline, fp, save_image_plane_details, sanitize=False):
                 phrase in setting.text.lower()
                 for phrase in ("username", "password", "host")
             ):
-                setting.unicode_value = "*****"
-            fp.write(f"    {setting.text}:{setting.unicode_value}\n")
+                fp.write(f"    {setting.text}:*****\n")
+            else:
+                fp.write(f"    {setting.text}:{setting.unicode_value}\n")
 
     if save_image_plane_details:
         fp.write("\n")

--- a/cellprofiler_core/pipeline/io/_v5.py
+++ b/cellprofiler_core/pipeline/io/_v5.py
@@ -48,7 +48,7 @@ def dump(pipeline, fp, save_image_plane_details, sanitize=False):
                 phrase in setting.text.lower()
                 for phrase in ("username", "password", "host")
             ):
-                fp.write(f"    {setting.text}:*****\n")
+                fp.write(f"    [SensitiveSetting]:*****\n")
             else:
                 fp.write(f"    {setting.text}:{setting.unicode_value}\n")
 


### PR DESCRIPTION
Turns out you can't set `unicode_value` directly.