### PR TITLE
Implement settings key and validation for normalization factor

### DIFF
--- a/cellprofiler_core/preferences/__init__.py
+++ b/cellprofiler_core/preferences/__init__.py
@@ -336,6 +336,7 @@ WORKSPACE_CHOICE = "WorkspaceChoice"
 ERROR_COLOR = "ErrorColor"
 INTERPOLATION_MODE = "InterpolationMode"
 INTENSITY_MODE = "IntensityMode"
+NORMALIZATION_FACTOR = "NormalizationFactor"
 SAVE_PIPELINE_WITH_PROJECT = "SavePipelineWithProject"
 FILENAME_RE_GUESSES_FILE = "FilenameRegularExpressionGuessesFile"
 PATHNAME_RE_GUESSES_FILE = "PathnameRegularExpressionGuessesFile"
@@ -1796,19 +1797,31 @@ def set_choose_image_set_frame_size(w, h):
     config_write(CHOOSE_IMAGE_SET_FRAME_SIZE, "%d,%d" % (w, h))
 
 
-__normalization_factor = "1.0"
+__normalization_factor = None
 
 
 def get_normalization_factor():
     global __normalization_factor
-
+    if __normalization_factor is not None:
+        return __normalization_factor
+    if config_exists(NORMALIZATION_FACTOR):
+        __normalization_factor = config_read(NORMALIZATION_FACTOR)
+    else:
+        __normalization_factor = "1.0"
     return __normalization_factor
 
 
 def set_normalization_factor(normalization_factor):
     global __normalization_factor
-
+    try:
+        float(normalization_factor)
+    except ValueError:
+        print(
+            f"Unable to set {NORMALIZATION_FACTOR} to {normalization_factor}, value must be a number."
+        )
+        return
     __normalization_factor = normalization_factor
+    config_write(NORMALIZATION_FACTOR, normalization_factor)
 
 
 def add_progress_callback(callback):


### PR DESCRIPTION
Fixes CellProfiler/CellProfiler#4256

The setting previously didn't have a config key, so I've added one. The GUI actually treats it as a text control and lacks any validation whatsoever, and we don't have a preferences widget for floats, so to save time I've stayed away from making it an explicit float key. Instead I've put some basic validation on the text field. I doubt people use this often anyway.

On my end this successfully recalls on restarting CP. Someone on Mac should test this too due to the different key handling system.