### PR TITLE
Check that numeric settings dont have `metadata=True`

### DIFF
--- a/cellprofiler_core/setting/text/number/_number.py
+++ b/cellprofiler_core/setting/text/number/_number.py
@@ -14,6 +14,10 @@ class Number(Text):
             value = self.str_to_value(value)
         else:
             text_value = self.value_to_str(value)
+
+        if kwargs.pop("metadata", False):
+            raise ValueError("metadata=True is not a valid argument for a numeric setting.")
+
         super(Number, self).__init__(text, text_value, *args, **kwargs)
         self.__default = self.str_to_value(text_value)
         self.__minval = minval

--- a/tests/setting/test_setting.py
+++ b/tests/setting/test_setting.py
@@ -61,6 +61,10 @@ class TestIntegerSetting(unittest.TestCase):
         with pytest.raises(ValidationError):
             (lambda: s.test_valid(None))()
 
+    def test_03_01_no_metadata(self):
+        with self.assertRaises(ValueError):
+            Integer("foo", value=5, maxval=10, metadata=True)
+
 
 class TestFloatSetting(unittest.TestCase):
     def test_01_01_default(self):


### PR DESCRIPTION
As discussed in  https://github.com/CellProfiler/CellProfiler/issues/4276
metadata=True is not supported by Cellprofiler and will lead to issues during the GUI execution
Adding a value error should make this more explicit and prevent offending modules not to be loaded to begin with.
