### PR TITLE
Prevent the gui from crashing if `build_imported_metadata_extractor` fails

### DIFF
--- a/cellprofiler_core/modules/metadata.py
+++ b/cellprofiler_core/modules/metadata.py
@@ -4,6 +4,7 @@ import time
 import urllib.request
 
 import javabridge
+from javabridge.jutil import JavaException
 
 from ..constants.measurement import COLTYPE_FLOAT
 from ..constants.measurement import COLTYPE_INTEGER
@@ -1072,9 +1073,13 @@ not being applied, your choice on this setting may be the culprit.
                     fltr,
                 )
             elif group.extraction_method == X_IMPORTED_EXTRACTION:
-                imported_extractor = self.build_imported_metadata_extractor(
-                    group, extractor, for_metadata_only
-                )
+                try:
+                    imported_extractor = self.build_imported_metadata_extractor(
+                        group, extractor, for_metadata_only
+                    )
+                except JavaException:
+                    imported_extractor = None
+
                 if imported_extractor is not None:
                     javabridge.call(
                         extractor,


### PR DESCRIPTION
This concerns the issue:
CellProfiler/Cellprofiler#4280

This is a rather simple fix that just captures the JavaException to prevent the whole module to crash.
I think it might be better to raise a 'ValidationError' and make sure `get_metadata_keys` is run as part
of `validate_module` and only allow attempt to run `update_table` if the module is validly configured.

Not sure if this would be a good idea, if then the validation could only run if the actual file is present.