### PR TITLE
Fix notes decoding

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -577,6 +577,17 @@ class Pipeline:
                     value = eval(value)
                 except SyntaxError:
                     value = value[1:-1].replace('"', "").replace("'", "").split(",")
+                if any([chr(226) in line for line in value]):
+                    # There were some unusual UTF-8 characters present, let's try to fix them.
+                    try:
+                        value = [
+                            line.encode("raw-unicode-escape").decode("utf-8")
+                            for line in value
+                        ]
+                    except Exception as e:
+                        print(
+                            f"Error during notes decoding - {e} \nSome characters may have been lost"
+                        )
             else:
                 value = eval(value)
             if attribute in skip_attributes:

--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -572,7 +572,13 @@ class Pipeline:
             if len(a.split(":", 1)) != 2:
                 raise ValueError("Invalid attribute string: %s" % a)
             attribute, value = a.split(":", 1)
-            value = eval(value)
+            if attribute == "notes":
+                try:
+                    value = eval(value)
+                except SyntaxError:
+                    value = value[1:-1].replace('"', "").replace("'", "").split(",")
+            else:
+                value = eval(value)
             if attribute in skip_attributes:
                 continue
             # En/decode needed to read example cppipe format


### PR DESCRIPTION
Fix CellProfiler/CellProfiler#4296

I think the best thing we can do here is strip out the problem characters from Notes fields when we encounter decoding problems. It won't look as pretty but should allow these pipelines to be loaded.