### PR TITLE
trigger garbage collector after each image

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -1,5 +1,6 @@
 import bisect
 import datetime
+import gc
 import hashlib
 import importlib
 import io
@@ -1070,6 +1071,8 @@ class Pipeline:
                         measurements.add_experiment_measurement(EXIT_STATUS, "Failure")
 
                         return
+
+                gc.collect()
 
             # Close cached readers.
             # This may play a big role with cluster deployments or long standing jobs


### PR DESCRIPTION
This PR allows to keep the RAM usage down when computing many images.
It triggers python's garbage collector after each image has been processed.
Without this, the memory usage grows to very high levels with regard to what's really necessary.

Here are some measurements I did on a dataset of 50 images, having 2800x2800 pixels each.

Without the fix:

![image](https://user-images.githubusercontent.com/27284007/103090660-f680c080-45f1-11eb-8eb9-975db559afd8.png)

With the fix: (different y-scale !)

![image](https://user-images.githubusercontent.com/27284007/103090691-0ac4bd80-45f2-11eb-930c-86d868cd7a3c.png)

This issue exists in both Cell Profiler 3 and 4.