### PR TITLE
Fix hdf5 filelist generation

### DIFF
--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -11,6 +11,7 @@ import os
 import sys
 import threading
 import time
+import urllib.parse
 import uuid
 
 import h5py
@@ -1143,17 +1144,11 @@ class HDF5FileList(object):
             url = url
         else:
             url = str(url)
-        import urllib.parse, urllib.error
 
         split = urllib.parse.urlsplit(str(url))
-        schema = split[0]
-        if schema == "":
-            schema = None
-        if schema is not None:
-            rest = url.split(schema)[1]
-            if rest[0]==':':
-                rest=rest[1:]
-        else:
+        schema = split.scheme
+        rest = split.path
+        if schema in (None, ""):
             rest = url
 
         if schema is not None and schema.lower() == "omero":


### PR DESCRIPTION
The new URL parser introduced in #72 was failing to split paths properly on Windows. I believe it gets confused and can stop splitting if the same folder name is repeated twice within a path, but who knows. I hope this approach will fix it, but if someone could test on MacOS that'd be great.

To test:
- Load the example pipeline.
- Save as .cpproj
- Verify that loading that .cpproj restores the file list properly.