### PR TITLE
Reorder count in measurement names

### DIFF
--- a/cellprofiler_core/module/image_segmentation/_object_processing.py
+++ b/cellprofiler_core/module/image_segmentation/_object_processing.py
@@ -105,7 +105,7 @@ class ObjectProcessing(ImageSegmentation):
 
     def get_measurements(self, pipeline, object_name, category):
         if object_name == self.x_name.value and category == C_CHILDREN:
-            return [FF_COUNT % self.y_name.value]
+            return ["%s_Count" % self.y_name.value]
 
         if object_name == self.y_name.value:
             if category == C_NUMBER:

--- a/cellprofiler_core/setting/_measurement.py
+++ b/cellprofiler_core/setting/_measurement.py
@@ -85,6 +85,7 @@ class Measurement(Setting):
                 module.get_measurements(pipeline, object_name, category)
             )
         result = list(feature_names)
+        result = [feature if "Count_" not in feature else f"{feature.replace('Count_', '')}_Count" for feature in result ]
         result.sort()
         return result
 

--- a/cellprofiler_core/setting/_measurement.py
+++ b/cellprofiler_core/setting/_measurement.py
@@ -85,7 +85,6 @@ class Measurement(Setting):
                 module.get_measurements(pipeline, object_name, category)
             )
         result = list(feature_names)
-        result = [feature if "Count_" not in feature else f"{feature.replace('Count_', '')}_Count" for feature in result ]
         result.sort()
         return result
 

--- a/tests/module/test_object_processing.py
+++ b/tests/module/test_object_processing.py
@@ -251,7 +251,7 @@ class TestObjectProcessing:
         )
 
         expected = [
-            cellprofiler_core.constants.measurement.FF_COUNT % "ObjectProcessing"
+            "%s_Count" % "ObjectProcessing"
         ]
 
         assert actual == expected


### PR DESCRIPTION
Fixes https://github.com/CellProfiler/CellProfiler/issues/4381

Briefly, object counts created by anything in the ObjectProcessing class use a different feature-order-structure than literally every other measurement in CellProfiler, I'm guessing due to historical accident; rather than Children_Count_ChildObjectName, within the measurement database we structure them as Children_ChildObjectName_Count.

This would be fine and dandy, except at the image level we use Count_ChildObjectName, so that's what's used in [FF_COUNT](https://github.com/CellProfiler/core/blob/master/cellprofiler_core/constants/measurement.py#L90), which is what's returned in object processing's [get_measurements](https://github.com/CellProfiler/core/blob/master/cellprofiler_core/module/image_segmentation/_object_processing.py#L106-L108). Anything that downstream wants to use the CellProfiler dropdowns to use that count of children measurement (at a minimum, we found it in FilterObjects, ClassifyObjects, and DisplayDataOnImage) is therefore looking for Count_ChildObjectName instead of ChildObjectName_Count. This allows them to look for the right thing, fixing at least those 3 modules.

It's probably worth discussing for CellProfiler 5 if we want to normalize it to Children_Count_ChildObjectName , but it would be a breaking change for anything downstream of CellProfiler that accesses object counts (which we suspect is a mess-ton of things), so worth just being inconsistent for the time being.