### PR TITLE
Add h5py 3 support, bump version

### DIFF
--- a/cellprofiler_core/measurement/_measurements.py
+++ b/cellprofiler_core/measurement/_measurements.py
@@ -815,6 +815,8 @@ class Measurements:
         #
         if getattr(v, "__class__") == str:
             return v
+        elif getattr(v, "__class__") == bytes:
+                return v.decode()
         return v
 
     def get_measurement(self, object_name, feature_name, image_set_number=None):

--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -434,6 +434,26 @@ class HDF5Dict(object):
                 # if fetching more than 1/2 of indices
                 #
                 dataset = dataset[:]
+            if dataset.dtype == numpy.object:
+                # Strings come back out as bytes, we need to decode them.
+                try:
+                    return [
+                        None
+                        if (
+                            isinstance(dest, slice)
+                            and dest.start is not None
+                            and dest.start == dest.stop
+                        )
+                        else dataset[dest].astype(str)
+                        for dest in [
+                            indices.get(image_number, (slice(0, 0), 0))[0]
+                            for image_number in num_idx
+                        ]
+                    ]
+                except Exception as e:
+                    logging.error(
+                        "Unable to decode object measurement. You may find bytes in your output sheet."
+                    )
             return [
                 None
                 if (

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "boto3>=1.12.28",
         "centrosome==1.2.0",
         "docutils==0.15.2",
-        "h5py==2.10.0",
+        "h5py==3.2.1",
         "matplotlib>=3.1.3",
         "numpy>=1.18.2",
         "prokaryote==2.4.2",

--- a/tests/measurement/test_measurements.py
+++ b/tests/measurement/test_measurements.py
@@ -20,10 +20,9 @@ class TestMeasurements:
         x = cellprofiler_core.measurement.Measurements()
 
     def test_00_01_wrap_unwrap(self):
-        test0 = ["foo", "foo\\", "foo\\u0384", "foo\\u0384"]
-        test = test0 + [x.encode("utf-8") for x in test0]
+        test = ["foo", "foo\\", "foo\\u0384", "foo\\u0384"]
         # numpy.object_
-        test += numpy.array(test0, object).tolist()
+        test += numpy.array(test, object).tolist()
         for case in test:
             result = cellprofiler_core.measurement.Measurements.unwrap_string(
                 cellprofiler_core.measurement.Measurements.wrap_string(case)


### PR DESCRIPTION
Resolves  CellProfiler/CellProfiler#4306

Seeing as h5Py 2 doesn't support Python 3.9+, we kinda need to upgrade. It looks like most functionality was fine, but we had some trouble with the string handling changes. h5py 3 now tends to return strings as bytes objects, so I've added a step to attempt to decode these. Seems to get all tests passing and I can run the example pipeline without issue now.

We might want to do some further testing before merging, but I think we should be good. The change should also be backwards-compatible with h5py 2.