### PR TITLE
Support aggregation of non-numeric features without crashing

### DIFF
--- a/cellprofiler_core/measurement/_measurements.py
+++ b/cellprofiler_core/measurement/_measurements.py
@@ -1195,6 +1195,9 @@ class Measurements:
                     continue
                 feature_name = "%s_%s" % (object_name, feature)
                 values = self.get_measurement(object_name, feature, image_set_number)
+                if not numpy.issubdtype(values.dtype, numpy.number):
+                    # Can't generate aggregate values for non-numeric measurements
+                    values = None
                 if values is not None:
                     values = values[numpy.isfinite(values)]
                 #


### PR DESCRIPTION
Required by CellProfiler/CellProfiler#4391. Having string-based measurements shouldn't completely crash attempts at aggregating columns. This will populate aggregate measurements with NaN instead.