### PR TITLE
add channelstack property

### DIFF
--- a/cellprofiler_core/image/_image.py
+++ b/cellprofiler_core/image/_image.py
@@ -66,6 +66,7 @@ class Image:
         scale=None,
         dimensions=2,
         spacing=None,
+        channelstack=False
     ):
         self.__image = None
 
@@ -101,6 +102,8 @@ class Image:
         self.dimensions = dimensions
 
         self.__spacing = spacing
+
+        self.__channelstack = channelstack
 
     @property
     def multichannel(self):
@@ -382,3 +385,12 @@ class Image:
             return self.parent_image.scale
 
         return self.__scale
+
+    @property
+    def channelstack(self):
+        if self.__channelstack is not None:
+            return self.__channelstack
+
+    @channelstack.setter
+    def channelstack(self, channelstack):
+        self.__channelstack = channelstack

--- a/tests/image/test_image.py
+++ b/tests/image/test_image.py
@@ -148,3 +148,14 @@ class TestImage:
         )
 
         assert x.spacing == (0.77 / 0.33, 1.0, 1.0)
+
+    def test_channelstack(self):
+        data = numpy.ones((5, 10, 10))
+
+        x = cellprofiler_core.image.Image(image=data)
+
+        assert x.channelstack == False
+
+        x.channelstack = True
+
+        assert x.channelstack == True


### PR DESCRIPTION
Add a new property which determines if an image should be treated as an RGB image or several independent stacked single-channel images for saving.  Required for proper handling between 3-and-4-stacked channel images vs RGB(A) images.