### PR TITLE
Fix NamesAndTypes list index error when files are missing

### DIFF
--- a/cellprofiler_core/setting/_image_plane.py
+++ b/cellprofiler_core/setting/_image_plane.py
@@ -55,7 +55,10 @@ class ImagePlane(Setting):
         )
 
     def __get_field(self, index):
-        f = self.value_text.split(" ")[index]
+        split = self.value_text.split(" ")
+        if index >= len(split):
+            return None
+        f = split[index]
         if len(f) == 0:
             return None
         return f


### PR DESCRIPTION
This primarily addresses a less-than-useful error that'd occur when a specified single image file is missing.

To create the error:
- Create a pipeline that specifies a single image in NamesAndTypes.
- Save the pipeline as cpproj and cppipe.
- Remove or rename the single image.
- Load from cpproj and enter test mode --> FileNotFoundError (good)
- Load from cppipe and enter test mode --> IndexError (bad)

I believe this happens because image plane details are cached in proj files from the last time the image was seen, but this doesn't apply to cppipe. If plane details are missing the class is set up to just use the base URL, but this cannot be split to generate plane details when requested. NamesAndTypes requests plane details before verifying that the file is still accessible, so an error occurs.

To resolve this I've made it so that bad plane details requests will return None (which already happens in other scenarios where this data is absent). This lets the module get through to the proper FileNotFoundError.