### PR TITLE
Fix loading of older cpproj files

### DIFF
--- a/cellprofiler_core/workspace/_workspace.py
+++ b/cellprofiler_core/workspace/_workspace.py
@@ -387,6 +387,16 @@ class Workspace:
                         .decode("unicode_escape")
                         .replace("ÿþ", "")
                     )
+                if "\\n" in pipeline_txt:
+                    # Loaded pipeline text from a pre-h5py 3 hdf5 will have escaped characters in need of decoding.
+                    try:
+                        pipeline_txt = pipeline_txt.encode(
+                            "latin-1", "backslashreplace"
+                        ).decode("unicode-escape")
+                    except Exception as e:
+                        print(
+                            f"Unable to fully decode pipeline, you may encounter some errors. Issue was: {e}"
+                        )
                 self.pipeline.load(io.StringIO(pipeline_txt))
             elif load_pipeline:
                 self.pipeline.clear()


### PR DESCRIPTION
Found this while loading some old projects. Turns out the change in h5py version interferes with the parsing of the stored pipeline text. It needed a little extra decoding to load properly. In 4.2.0 the attached pipeline should silently fail to load without this fix.

[BuggedProj.zip](https://github.com/CellProfiler/core/files/6818561/BuggedProj.zip)
