### PR TITLE
Remove redundant alternative hdf5 writing method

### DIFF
--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -874,28 +874,15 @@ class HDF5Dict(object):
 
             self.__cache_index(object_name, feature_name, idx)
             feature_group = self.top_group[object_name][feature_name]
-            if dataset.dtype.kind.upper() == "O":
-                dest = feature_group.create_dataset(
-                    "data",
-                    dtype=h5py.special_dtype(vlen=str),
-                    compression="gzip",
-                    shuffle=True,
-                    chunks=(self.chunksize,),
-                    shape=dataset.shape,
-                    maxshape=(None,),
-                )
-                for i, value in enumerate(dataset):
-                    dest[i] = value
-            else:
-                feature_group.create_dataset(
-                    "data",
-                    data=dataset,
-                    dtype=dtype,
-                    compression="gzip",
-                    shuffle=True,
-                    chunks=(self.chunksize,),
-                    maxshape=(None,),
-                )
+            feature_group.create_dataset(
+                "data",
+                data=dataset,
+                dtype=dtype,
+                compression="gzip",
+                shuffle=True,
+                chunks=(self.chunksize,),
+                maxshape=(None,),
+            )
             feature_group.create_dataset(
                 "index",
                 data=idx,


### PR DESCRIPTION
A while back there was some sort of problem when storing numpy arrays with mixed data types. That was fixed [here](https://github.com/CellProfiler/CellProfiler/commit/ffe716d2a05273f6ee88b217e84290d4e7b95a2d).

In this fix, hdf5 arrays with the 'object' dtype are stored by creating a blank entry and then writing each measurement individually. Particularly when running NamesAndTypes this becomes exceptionally slow if working with a large file list. It potentially turns a single write operation into many thousands.

Since we're now on h5py 3, I've tried removing this special handling. Doing so seems to dramatically improve the performance of NamesAndTypes matching without breaking the tests made to catch this error. In testing I saw around a 25-fold decrease in time taken to pair 3000 image sets. It looks like modern HDF5 may not have the problem this code was added to resolve.

We should do some rigorous testing with full pipelines, but with any luck this might make the input modules less painful to use with complex datasets.