### PR TITLE
Fix progress dialogs in prepare_run

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -1255,7 +1255,8 @@ class Pipeline:
         orig_image_number = m.image_set_number
 
         progress_dialog = self.create_progress_dialog(message, pipeline, title)
-
+        if progress_dialog is not None:
+            progress_dialog.SetRange(len(image_numbers))
         try:
             for i, image_number in enumerate(image_numbers):
                 m.image_set_number = image_number


### PR DESCRIPTION
Fixes CellProfiler/CellProfiler#4448

In wx4 progress updates can no longer exceed the max value on the bar. To fix this we set the range explicitly before using the progress bar.

To test: Make a pipeline with RescaleIntensity in "Custom value" mode, determined by min or max of all images. Load in more than 100 images.