### PR TITLE
Improve JSON handling, support JSON pipelines in headless mode

### DIFF
--- a/cellprofiler_core/pipeline/io/_v6.py
+++ b/cellprofiler_core/pipeline/io/_v6.py
@@ -53,17 +53,12 @@ def dump(pipeline, fp, save_image_plane_details):
 
 def load(pipeline, fd):
     pipeline_dict = json.load(fd)
-
-    for module in pipeline.modules():
-        pipeline.remove_module(module.module_num)
-
+    pipeline_modules = pipeline.modules(False)
+    pipeline_modules.clear()
     for module in pipeline_dict["modules"]:
-        module_path = module["attributes"]["module_path"]
+        module_name = module["attributes"]["module_name"]
         settings = [setting_dict for setting_dict in module["settings"]]
-        parts = module_path.split(".")
-        module_class = __import__(parts[0])
-        for part in parts[1:]:
-            module_class = getattr(module_class, part)
-        new_module = module_class()
+        new_module = pipeline.instantiate_module(module_name)
         new_module.from_dict(settings, module["attributes"])
-        pipeline.add_module(new_module)
+        pipeline_modules.append(new_module)
+


### PR DESCRIPTION
Fixes CellProfiler/CellProfiler#4477

In this PR I've moved JSON format detection into core as opposed to the GUI PipelineController. This allows for the format to be used without the GUI.

I've also revised the loading sequence to be more like the other pipeline file loaders. Sending events to remove and add modules individually tended to cause strange behaviour when loading multiple pipelines after eachother, and sometimes the GUI would fail to update. It could also get confused as it didn't always update the hidden settings list. Doing the operations in bulk and sending the PipelineLoaded event seems to behave more reliably.

As part of making this work in headless mode, I've switched the module generator over to using `instantiate_module` as opposed to manually finding the relevant class. This is needed in headless mode because the internal module list is not populated automatically until a module runs this method. Using this also allows us to search the main module list by name instead of having to figure out whether it's a core, non-core or plugin module.

Requires CellProfiler/CellProfiler#4479