### PR TITLE
Allow settings upgrades for JSON pipelines

### DIFF
--- a/cellprofiler_core/module/_module.py
+++ b/cellprofiler_core/module/_module.py
@@ -1,4 +1,5 @@
 import abc
+import logging
 import sys
 import uuid
 
@@ -106,12 +107,15 @@ class Module:
         self.wants_pause = attributes["wants_pause"]
         self.svn_version = attributes["svn_version"]
         self.enabled = attributes["enabled"]
-        self.variable_revision_number = attributes["variable_revision_number"]
         self.module_path = attributes["module_path"]
         self.module_name = attributes["module_name"]
         setting_values = [setting["value"] for setting in settings]
+        if attributes["variable_revision_number"] > self.variable_revision_number:
+            logging.warning(f"Loaded module '{self.module_name}' is from a newer version of CellProfiler - "
+                            f"v{attributes['variable_revision_number']}, current version is "
+                            f"v{self.variable_revision_number}. Settings may load incorrectly.")
         self.set_settings_from_values(
-            setting_values, self.variable_revision_number, self.module_path
+            setting_values, attributes['variable_revision_number'], self.module_path
         )
 
     @abc.abstractmethod

--- a/cellprofiler_core/pipeline/io/_v6.py
+++ b/cellprofiler_core/pipeline/io/_v6.py
@@ -53,6 +53,11 @@ def dump(pipeline, fp, save_image_plane_details):
 
 def load(pipeline, fd):
     pipeline_dict = json.load(fd)
+    cp_version = int(re.sub(r"\.|rc\d", "", cellprofiler_core.__version__))
+    if cp_version != pipeline_dict['date_revision']:
+        logging.warning(f"Pipeline file is from a different version of CellProfiler. "
+                        f"Current:v{cp_version} File:v{pipeline_dict['date_revision']}."
+                        f" Will attempt to upgrade settings.")
     pipeline_modules = pipeline.modules(False)
     pipeline_modules.clear()
     for module in pipeline_dict["modules"]:


### PR DESCRIPTION
Currently the module version variable `variable_revision_number` is being overwritten with whatever number is within the incoming pipeline. This is basically a bug and will cause problems when loading into mismatched versions of CellProfiler.

In this PR, we instead provide the pipeline's module revision number to the settings loader. This will trigger it to automatically attempt to upgrade the settings to match the module version in the CellProfiler environment.

I've also added logged warnings for when pipeline and cellprofiler versions are different, and for instances where a module's settings are from a newer version of the module than is installed.