### PR TITLE
Fix crash in ExportToSpreadsheet when using ExportToDatabase to generate CPA properties files

### DIFF
--- a/cellprofiler_core/constants/measurement.py
+++ b/cellprofiler_core/constants/measurement.py
@@ -5,6 +5,7 @@ AGG_NAMES = [AGG_MEAN, AGG_MEDIAN, AGG_STD_DEV]
 IMAGE = "Image"
 EXPERIMENT = "Experiment"
 RELATIONSHIP = "Relationship"
+DB_TEMP = "ExportToDb"
 NEIGHBORS = "Neighbors"
 OBJECT = "Object"
 disallowed_object_names = [IMAGE, EXPERIMENT, RELATIONSHIP]

--- a/cellprofiler_core/measurement/_measurements.py
+++ b/cellprofiler_core/measurement/_measurements.py
@@ -33,6 +33,7 @@ from ..constants.measurement import C_OBJECTS_URL
 from ..constants.measurement import C_PATH_NAME
 from ..constants.measurement import C_SERIES
 from ..constants.measurement import C_URL
+from ..constants.measurement import DB_TEMP
 from ..constants.measurement import EXPERIMENT
 from ..constants.measurement import GROUP_INDEX
 from ..constants.measurement import GROUP_NUMBER
@@ -741,7 +742,8 @@ class Measurements:
     def get_object_names(self):
         """The list of object names (including Image) that have measurements
         """
-        return [x for x in self.hdf5_dict.top_level_names() if x != RELATIONSHIP]
+        return [x for x in self.hdf5_dict.top_level_names() if x not in (DB_TEMP, RELATIONSHIP)]
+        # return [x for x in self.hdf5_dict.top_level_names() if x not in (RELATIONSHIP)]
 
     object_names = property(get_object_names)
 

--- a/cellprofiler_core/measurement/_measurements.py
+++ b/cellprofiler_core/measurement/_measurements.py
@@ -743,7 +743,6 @@ class Measurements:
         """The list of object names (including Image) that have measurements
         """
         return [x for x in self.hdf5_dict.top_level_names() if x not in (DB_TEMP, RELATIONSHIP)]
-        # return [x for x in self.hdf5_dict.top_level_names() if x not in (RELATIONSHIP)]
 
     object_names = property(get_object_names)
 


### PR DESCRIPTION
In CellProfiler/CellProfiler#4396 we added a temporary measurement to track how many channels input images had. This is stored as the `ExportToDb` measurement type and would usually be deleted before we do database writing.

However, if a user has both ExportToSpreadsheet and ExportToDatabase modules in a pipeline, and also enables CPA properties file generation, there are situations where ExportToSpreadsheet would try to grab and write the temporary column, causing a crash in post_group.

To fix this I've excluded the temporary measurement from the measurements dict column list fetcher.