### PR TITLE
Fix for NamesAndTypes manual threshold

### DIFF
--- a/cellprofiler_core/image/abstract_image/file/_file_image.py
+++ b/cellprofiler_core/image/abstract_image/file/_file_image.py
@@ -280,7 +280,7 @@ class FileImage(AbstractImage):
                     c=self.channel,
                     series=self.series,
                     index=self.index,
-                    rescale=self.rescale,
+                    rescale=self.rescale if isinstance(self.rescale, bool) else False,
                     wants_max_intensity=True,
                     channel_names=channel_names,
                 )
@@ -302,7 +302,7 @@ class FileImage(AbstractImage):
                         c=channel,
                         series=series,
                         index=index,
-                        rescale=self.rescale,
+                        rescale=self.rescale if isinstance(self.rescale, bool) else False,
                         wants_max_intensity=True,
                         channel_names=channel_names,
                     )


### PR DESCRIPTION
Fixes CellProfiler/CellProfiler#4470

Within core/image/abstract_image/file/url/_file_image.py images are loaded using bioformats get_image_reader which has a rescale option (True or False, default True) to scale the intensity range between 0 and 1. In NamesAndTypes, if the user selects to rescale using metadata then True is passed to get_image_reader rescale. If image bit-depth is selected, False is passed. If a manual value is selected that value is passed, which leads to get_image_reader defaulting and using rescale=True. 

Later, line 315 in _file_image.py, the option of manual rescale is considered and then applied to the already bioformats rescaled image. 

This PR fixes this issue by checking if self.rescale is a bool and if not, return False. If False, the image will be rescaled between 0-1 by CellProfiler, independently of bioformats get_image_reader, based on the users inputted manual image bit-depth.