### PR TITLE
Fix for NamesAndTypes incorrectly relabeling 3D objects from an image

### DIFF
--- a/cellprofiler_core/image/abstract_image/file/url/_objects_image.py
+++ b/cellprofiler_core/image/abstract_image/file/url/_objects_image.py
@@ -86,9 +86,9 @@ class ObjectsImage(URLImage):
 
     def get_image_volume(self):
         imdata = self.__data
-        planes = []  # newplanes = numpy.zeros_like(test2)
+        planes = []
         for planeid in range(imdata.shape[0]):
-            planes.append(convert_image_to_objects(imdata[planeid]).astype(numpy.int32))
+            planes.append(imdata[planeid].astype(numpy.int32))
         imdata = numpy.stack(planes)
 
         image = Image(


### PR DESCRIPTION
Tentative fix for CellProfiler/CellProfiler#4505

When loading objects from a 3d image, NamesAndTypes relied on a method (specifically, [get_image_volume ](https://github.com/CellProfiler/core/blob/59f412cbb70fc4e1c5f3a242967b7b865deeebad/cellprofiler_core/image/abstract_image/file/url/_objects_image.py#L87)in core _objects_image.py) that labelled planes individually using `convert_image_to_objects` and stacked the result. As some cells can be present in one plane but not others, this led to differences in labelling for the same cell between planes. By removing the label recalculations, the original segmentation is preserved. 

@DavidStirling , is there some particular scenario this original fix was trying to solve? We note that planes are converted from int64 to int32 here, which we have preserved, so wondered if theres some particular case we are overlooking here. Could it also be that `convert_image_to_objects` was called to help deal with missing objects, similar to CellProfiler/CellProfiler#4485?