### PR TITLE
Skiamge 0.19 compatibility

### DIFF
--- a/cellprofiler_core/image/abstract_image/file/url/_color_image.py
+++ b/cellprofiler_core/image/abstract_image/file/url/_color_image.py
@@ -24,6 +24,6 @@ class ColorImage(URLImage):
         image = URLImage.provide_image(self, image_set)
 
         if image.pixel_data.ndim == image.dimensions:
-            image.pixel_data = skimage.color.gray2rgb(image.pixel_data, alpha=False)
+            image.pixel_data = skimage.color.gray2rgb(image.pixel_data)
 
         return image


### PR DESCRIPTION
The only test that fails in either core or CellProfiler when upgrading to latest skimage are ones related to this, since alpha was removed from this - the other place in the code where we use gray2rgb, we don't use alpha. 