### PR TITLE
Channelstack for loading in 4+ channel non-volumetric images

### DIFF
--- a/cellprofiler_core/image/abstract_image/file/_file_image.py
+++ b/cellprofiler_core/image/abstract_image/file/_file_image.py
@@ -316,6 +316,7 @@ class FileImage(AbstractImage):
             path_name=self.get_pathname(),
             file_name=self.get_filename(),
             scale=self.scale,
+            channelstack=img.ndim == 3 and img.shape[-1]>3
         )
         if img.ndim == 3 and len(channel_names) == img.shape[2]:
             self.__image.channel_names = list(channel_names)


### PR DESCRIPTION
Resolves https://github.com/CellProfiler/CellProfiler/issues/4032
Resolves https://github.com/CellProfiler/CellProfiler/issues/4495

In #80 and https://github.com/CellProfiler/CellProfiler/pull/4406 , we added an image property called `channelstack` that we could use when saving >3 channel color images that we had created ourselves in GrayToColor to avoid the nasty issues in https://github.com/CellProfiler/CellProfiler/issues/4401 . We didn't anticipate though that some people would want to save out input images without any changes at all though, so those still had the same transposition issue.  This allows users to do that. 