### PR TITLE
Replace numpy object check with builtin

### DIFF
--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -434,7 +434,7 @@ class HDF5Dict(object):
                 # if fetching more than 1/2 of indices
                 #
                 dataset = dataset[:]
-            if dataset.dtype == numpy.object:
+            if dataset.dtype == object:
                 # Strings come back out as bytes, we need to decode them.
                 try:
                     return [


### PR DESCRIPTION
- addresses numpy deprecation warning
- part of [cp pr
  #4576](https://github.com/CellProfiler/CellProfiler/pull/4576)