### PR TITLE
Close h5py file if needed

### DIFF
--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -403,7 +403,10 @@ class HDF5Dict(object):
                 self.hdf5_file.close()
                 with open(self.filename, "rb") as f:
                     mem = memoryview(f.read())
-                self.hdf5_file = h5py.File(self.filename, mode = self.mode)
+                if 'w' not in self.mode:
+                    self.hdf5_file = h5py.File(self.filename, mode = self.mode)
+                else:
+                    self.hdf5_file = h5py.File(self.filename, mode = "a")
                 return mem
 
     @classmethod

--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -149,7 +149,7 @@ class HDF5Dict(object):
                          from different CellProfiler runs by using a different
                          run group name. If you open the file as
         """
-        assert mode in ("r", "r+", "w", "x", "w-", "a") # https://github.com/CellProfiler/CellProfiler/commit/52f8208f0f39e0f34176e92db4e90d7f15419a83#diff-e84f81e2ad1b8cda19f1761e1fd5a6704310848c80f0e3b860e48a1f736e7cefR142
+        assert mode in ("r", "r+", "w", "x", "w-", "a")
         self.mode = mode
         file_exists = (hdf5_filename is not None) and os.path.exists(hdf5_filename)
         default_run_group_name = time.strftime("%Y-%m-%d-%H-%m-%S")

--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -150,8 +150,6 @@ class HDF5Dict(object):
                          run group name. If you open the file as
         """
         assert mode in ("r", "r+", "w", "w+", "w-", "a")
-        self.mode = mode
-        open_mode = mode
         file_exists = (hdf5_filename is not None) and os.path.exists(hdf5_filename)
         default_run_group_name = time.strftime("%Y-%m-%d-%H-%m-%S")
         if mode in ("r", "r+"):
@@ -162,7 +160,10 @@ class HDF5Dict(object):
             load_measurements = False
             run_group_name = default_run_group_name
             if mode == "w+" and file_exists:
-                open_mode = "r+"
+                mode = "r+"
+            elif mode == "w+":
+                mode = "a"
+        self.mode = mode
 
         self.is_temporary = is_temporary and (hdf5_filename is not None)
         self.filename = hdf5_filename
@@ -172,7 +173,7 @@ class HDF5Dict(object):
             self.filename,
             self.is_temporary,
             copy,
-            open_mode,
+            mode,
         )
         if self.filename is None:
             # core driver requires a unique filename even if the file
@@ -395,9 +396,9 @@ class HDF5Dict(object):
                 with open(self.filename, "rb") as f:
                     mem = memoryview(f.read())
                 if 'w' not in self.mode:
-                    self.hdf5_file = h5py.File(self.filename, mode = self.mode)
+                    self.hdf5_file = h5py.File(self.filename, mode=self.mode)
                 else:
-                    self.hdf5_file = h5py.File(self.filename, mode = "a")
+                    self.hdf5_file = h5py.File(self.filename, mode="a")
 
                 #We need to reopen the old group, not just the old file
                 mgroup = self.hdf5_file[self.top_level_group_name]

--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -154,7 +154,6 @@ class HDF5Dict(object):
         open_mode = mode
         file_exists = (hdf5_filename is not None) and os.path.exists(hdf5_filename)
         default_run_group_name = time.strftime("%Y-%m-%d-%H-%m-%S")
-        self.default_run_group_name = default_run_group_name
         if mode in ("r", "r+"):
             load_measurements = True
         elif mode == "a" and file_exists:

--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -149,7 +149,8 @@ class HDF5Dict(object):
                          from different CellProfiler runs by using a different
                          run group name. If you open the file as
         """
-        assert mode in ("r", "r+", "w", "w+", "w-", "a")
+        assert mode in ("r", "r+", "w", "x", "w-", "a") # https://github.com/CellProfiler/CellProfiler/commit/52f8208f0f39e0f34176e92db4e90d7f15419a83#diff-e84f81e2ad1b8cda19f1761e1fd5a6704310848c80f0e3b860e48a1f736e7cefR142
+        self.mode = mode
         file_exists = (hdf5_filename is not None) and os.path.exists(hdf5_filename)
         default_run_group_name = time.strftime("%Y-%m-%d-%H-%m-%S")
         if mode in ("r", "r+"):
@@ -159,11 +160,6 @@ class HDF5Dict(object):
         else:
             load_measurements = False
             run_group_name = default_run_group_name
-            if mode == "w+" and file_exists:
-                mode = "r+"
-            elif mode == "w+":
-                mode = "a"
-        self.mode = mode
 
         self.is_temporary = is_temporary and (hdf5_filename is not None)
         self.filename = hdf5_filename

--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -228,8 +228,6 @@ class HDF5Dict(object):
                 self.version = self.hdf5_file[VERSION][0]
                 self.indices = {}
 
-            self.run_group_name = run_group_name
-
             self.lock = HDF5Lock()
 
             self.chunksize = 1024
@@ -403,7 +401,8 @@ class HDF5Dict(object):
 
                 #We need to reopen the old group, not just the old file
                 mgroup = self.hdf5_file[self.top_level_group_name]
-                self.top_group = mgroup[self.run_group_name]
+                run_group_name = sorted(mgroup.keys())[-1]
+                self.top_group = mgroup[run_group_name]
                 return mem
 
     @classmethod


### PR DESCRIPTION
So I'm still not sure why it's OS specific or h5py version specific, but the cranky behavior in Windows was this - in order to have the measurements in something speedy, it was opening another copy of the file in rb mode so that memoryview has bytes. 

I tried to come up with some more elegant solutions, including trying the [swmr mode](https://docs.h5py.org/en/stable/swmr.html), but none of those were working. So for now, let's just close the file so that we can read it, then reopen it. Tests are now passing on Windows, and it seems to be running in my hands. If we come up with a better solution later, great.