### PR TITLE
Release memory for redundant images in analysis mode

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -21,6 +21,7 @@ import numpy
 from . import ImageFile
 from .io import dump as dumpit
 from ..constants.reader import all_readers
+from ..setting.multichoice import ImageNameSubscriberMultiChoice
 from ..setting.subscriber import ImageSubscriber
 from ..setting.subscriber import ImageListSubscriber
 from ..utilities.core.modules import instantiate_module, reload_modules
@@ -1381,6 +1382,11 @@ class Pipeline:
                     names_to_modules[setting.value] = module
                 elif isinstance(setting, ImageListSubscriber):
                     for item in setting.value:
+                        if item in ("None", None):
+                            continue
+                        names_to_modules[item] = module
+                elif isinstance(setting, ImageNameSubscriberMultiChoice):
+                    for item in setting.get_selections():
                         if item in ("None", None):
                             continue
                         names_to_modules[item] = module

--- a/cellprofiler_core/preferences/__init__.py
+++ b/cellprofiler_core/preferences/__init__.py
@@ -405,10 +405,11 @@ FLOAT_KEYS = {TITLE_FONT_SIZE, TABLE_FONT_SIZE, PIXEL_SIZE}
 #######################
 CONSERVE_MEMORY_HELP = """\
 If enabled, CellProfiler will attempt to release unused system memory
-after processing each image in an analysis run. This can help to
-conserve system resources if the user is running other tasks in the
-background. Enabling this setting may slightly impact analysis speed,
-particularly during large runs.\
+after processing each image in an analysis run. Image pixel data will 
+also be 'forgotten' if an image is no longer required by later modules 
+in the pipeline. This can help to conserve system resources if the 
+user is running other tasks in the background. Enabling this setting 
+may slightly impact analysis speed, particularly during large runs.\
 """
 
 DEFAULT_COLORMAP_HELP = """\

--- a/cellprofiler_core/worker/_worker.py
+++ b/cellprofiler_core/worker/_worker.py
@@ -157,6 +157,7 @@ class Worker:
                 current_pipeline.add_listener(self.pipeline_listener.handle_event)
                 current_preferences = rep.preferences
                 self.pipeline = current_pipeline
+                self.pipeline.calculate_last_image_uses()
                 self.preferences = current_preferences
             else:
                 # update preferences to match remote values


### PR DESCRIPTION
Fixes CellProfiler/CellProfiler#4025

Scenario: You're working on a large 3D image. You run Smooth to aid in thresholding but you never need the smoothed image again for the rest of the 30-module pipeline. In current CellProfiler that image data needs to be kept in memory, which can cause problems with large images in complex pipelines. With this PR CellProfiler should be able to (gracefully?) forget that image once it's been used for the last time.

I've placed this under the control of the existing `conserve memory` setting. Obviously this only applies during an analysis run since Test Mode can move back and forth. I believe `ImageNameSubscriber` and `ImageListSubscriber` are the only setting types that can select an image for fetching pixel data but there may be others - might be worth checking some of the ExportTo___ module settings.

How it works: CellProfiler workers now only have to worry about a single pipeline. When that pipeline is loaded we run a function which scans each module for image-using settings and records which module is the last to use each image name. Once this is complete we flip the dictionary to create a map linking module objects to a list of image names which are no longer needed in the rest of the pipeline. During a run we can then query this map for which images need to be forgotten. When running the memory release process is skipped for the last module since we're done by that point anyway.