### PR TITLE
Fix pytest warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
             "sphinx==3.1.2",
             "twine==3.1.1",
         ],
-        "test": ["pytest==5.4.1"],
+        "test": ["pytest==5.4.1", "pytest-timeout==2.1.0"],
         "wx": ["wxPython==4.1.0"],
     },
     install_requires=[


### PR DESCRIPTION
Add dependency introduced in cb68608714fcebe7ac6ca732efb486a28bb9053a

Nothing was broken, but pytest was throwing warnings about the missing custom timeout marker.