### PR TITLE
Update namesandtypes.py

### DIFF
--- a/cellprofiler_core/modules/namesandtypes.py
+++ b/cellprofiler_core/modules/namesandtypes.py
@@ -1610,7 +1610,7 @@ requests an object selection.
             indexer = numpy.zeros(nobjects + 1, int)
             indexer[unique_labels] =contig_labels
             image.set_image(skimage.morphology.label(indexer[labels]), convert=False)
-        if shape[2] == 1 or volume:
+        if shape[2] == 1:
             o.segmented = image.pixel_data[:, :, 0]
             add_object_location_measurements(
                 workspace.measurements, name, o.segmented, o.count


### PR DESCRIPTION
Hi I was trying to measure Object Intensity in CP 4.2.4 and I was getting a dimension error (my y dimension had disappeared). I did not get this error in CP 4.2.1. I had imported the object in as object in the names and type module. My data is 3D. If I recreated the segmentation from the raw data the error did not appear + there is no differences in the measure  Object Intensity of CP4.2.4 and CP4.2.1 so it looks like the error comes from the names and type module. Changing that line allows my pipeline to run.