### PR TITLE
Delay get config

### DIFF
--- a/cellprofiler_core/reader/__init__.py
+++ b/cellprofiler_core/reader/__init__.py
@@ -43,7 +43,7 @@ def add_reader(reader_name, check_svn, class_name=None):
             del ALL_READERS[name]
 
 
-def fill_readers():
+def fill_readers(check_config=True):
     ALL_READERS.clear()
     BAD_READERS.clear()
 
@@ -55,17 +55,22 @@ def fill_readers():
         LOGGER.warning(
             f"could not load these readers: {', '.join(BAD_READERS)}"
         )
-    activate_readers()
-    if len(AVAILABLE_READERS) == 0:
-        LOGGER.critical("No image readers are available, CellProfiler won't be able to load data!")
+
+    activate_readers(check_config)
 
 
-def activate_readers():
+def activate_readers(check_config=True):
     AVAILABLE_READERS.clear()
     for reader_name, classname in ALL_READERS.items():
-        enabled = config_read_typed(f'Reader.{reader_name}.enabled', bool)
-        if enabled or enabled is None:
+        if check_config:
+            enabled = config_read_typed(f'Reader.{reader_name}.enabled', bool)
+            if enabled or enabled is None:
+                AVAILABLE_READERS[reader_name] = classname
+        else:
             AVAILABLE_READERS[reader_name] = classname
+
+    if len(AVAILABLE_READERS) == 0:
+        LOGGER.critical("No image readers are available, CellProfiler won't be able to load data!")
 
 
 def find_cp_reader(rdr):
@@ -122,3 +127,5 @@ def get_image_reader_by_name(reader_name):
         LOGGER.warning(f"Requested reader {reader_name} which is disabled by config."
                        f"CellProfiler will use this reader anyway.")
     return ALL_READERS[reader_name]
+
+fill_readers(check_config=False)

--- a/cellprofiler_core/reader/__init__.py
+++ b/cellprofiler_core/reader/__init__.py
@@ -122,6 +122,3 @@ def get_image_reader_by_name(reader_name):
         LOGGER.warning(f"Requested reader {reader_name} which is disabled by config."
                        f"CellProfiler will use this reader anyway.")
     return ALL_READERS[reader_name]
-
-
-fill_readers()

--- a/cellprofiler_core/readers/ngff_reader.py
+++ b/cellprofiler_core/readers/ngff_reader.py
@@ -31,6 +31,8 @@ class NGFFReader(Reader):
     """
 
     reader_name = "OME-NGFF"
+    variable_revision_number = 1
+    supported_filetypes = {'.zarr', '.ome.zarr'}
 
     # Reader cache maps a path to a tuple of (zarr_root_group, series_map).
     ZARR_READER_CACHE = {}


### PR DESCRIPTION
This PR is companion to CellProfiler/CellProfiler#4678, and is a slight modification to #126, which ~delays filling readers until after headless mode is determined~ adds a `check_config` flag to `fill_reader()` and `activate_reader`.

This is necessary because `fill_readers(check_config=True) -> activate_readers(check_config=True)` will call `config_read_typed() -> get_config()` which will  check if `__is_headless` is true before it has had a chance to be set by argument parsing.

Instead `fill_readers` is invoked with `check_config=False` on init. `activate_readers` can be re-invoked later, after argument parsing` with `check_config=True`.