### PR TITLE
Make GCS dependency mandatory

### DIFF
--- a/cellprofiler_core/pipeline/_image_file.py
+++ b/cellprofiler_core/pipeline/_image_file.py
@@ -151,6 +151,14 @@ class ImageFile:
     def url(self):
         return self._url
 
+    @property
+    def scheme(self):
+        protocol_idx = self._url.find(":")
+        if protocol_idx >= 0:
+            return self._url.lower()[0: protocol_idx]
+        else:
+            return None
+
     @cached_property
     def filename(self):
         return os.path.basename(self.path)

--- a/cellprofiler_core/reader/_reader.py
+++ b/cellprofiler_core/reader/_reader.py
@@ -25,6 +25,18 @@ class Reader(ABC):
 
     @property
     @abstractmethod
+    def supported_filetypes(self):
+        # This should be a class property. Give the reader a set of supported filetypes (extensions).
+        pass
+
+    @property
+    @abstractmethod
+    def supported_schemes(self):
+        # This should be a class property. Give the reader a set of supported schemes (e.g. file, https, s3, ...).
+        pass
+
+    @property
+    @abstractmethod
     def variable_revision_number(self):
         # This should be a class property. Give the reader a version number (int).
         pass

--- a/cellprofiler_core/readers/bioformats_reader.py
+++ b/cellprofiler_core/readers/bioformats_reader.py
@@ -15,6 +15,7 @@ from ..utilities.java import start_java
 # bioformats returns 2 for these, imageio reader returns 3
 SUPPORTED_EXTENSIONS = {'.tiff', '.tif', '.ome.tif', '.ome.tiff'}
 SEMI_SUPPORTED_EXTENSIONS = BIOFORMATS_IMAGE_EXTENSIONS
+SUPPORTED_SCHEMES = {'file', 'http', 'https', 'ftp', 'ftps', 'omero', 's3'}
 
 class BioformatsReader(Reader):
     """
@@ -140,7 +141,10 @@ class BioformatsReader(Reader):
 
         The volume parameter specifies whether the reader will need to return a 3D array.
         ."""
-        if image_file.url.lower().startswith("omero:"):
+        url_lower = image_file.url.lower()
+        if image_file.scheme not in SUPPORTED_SCHEMES:
+            return -1
+        if image_file.scheme == 'omero':
             return 1
         if image_file.full_extension in SUPPORTED_EXTENSIONS:
             return 2

--- a/cellprofiler_core/readers/bioformats_reader.py
+++ b/cellprofiler_core/readers/bioformats_reader.py
@@ -27,6 +27,7 @@ class BioformatsReader(Reader):
     reader_name = "Bio-Formats"
     variable_revision_number = 1
     supported_filetypes = BIOFORMATS_IMAGE_EXTENSIONS
+    supported_schemes = SUPPORTED_SCHEMES
 
     def __init__(self, image_file):
         self._reader = None

--- a/cellprofiler_core/readers/gcs_reader.py
+++ b/cellprofiler_core/readers/gcs_reader.py
@@ -1,11 +1,21 @@
 import os
+import io
 from urllib.parse import urlparse
+import logging
 
 import imageio
 from cellprofiler_core.readers.imageio_reader import ImageIOReader
+from cellprofiler_core.readers.imageio_reader import SUPPORTED_EXTENSIONS as IMAGEIO_SUPPORTED_EXTENSIONS
+from cellprofiler_core.readers.imageio_reader import SEMI_SUPPORTED_EXTENSIONS as IMAGEIO_SEMI_SUPPORTED_EXTENSIONS
 from google.cloud import storage
+from google.auth.exceptions import DefaultCredentialsError
+from google.cloud.exceptions import NotFound
+
+LOGGER = logging.getLogger(__name__)
 
 SUPPORTED_EXTENSIONS = {'.tiff'}
+SEMI_SUPPORTED_EXTENSIONS = IMAGEIO_SUPPORTED_EXTENSIONS.union(IMAGEIO_SEMI_SUPPORTED_EXTENSIONS).difference(SUPPORTED_EXTENSIONS)
+SUPPORTED_SCHEMES = {'gs'}
 
 
 class GcsReader(ImageIOReader):
@@ -40,19 +50,25 @@ class GcsReader(ImageIOReader):
         Any opened files should be closed before returning.
 
         The volume parameter specifies whether the reader will need to return a 3D array.
-        ."""
-        if image_file.url.lower().startswith("gs:") and image_file.file_extension in SUPPORTED_EXTENSIONS:
+        """
+        if image_file.scheme not in SUPPORTED_SCHEMES:
+            return -1
+
+        if image_file.file_extension in SUPPORTED_EXTENSIONS:
             return 1
-        return -1
+
+        if image_file.file_extension in SEMI_SUPPORTED_EXTENSIONS:
+            return 3
+
+        return 4
 
     def get_reader(self, volume=False):
-        # Download image from Google Cloud Storage bucket.
-        path_to_image = self.download_blob(self.file.url)
+        image_resource = self.__download_blob(self.file._url)
         if self._reader is None or volume != self._volume:
             if volume:
-                self._reader = imageio.get_reader(path_to_image, mode='v')
+                self._reader = imageio.get_reader(image_resource, mode='v')
             else:
-                self._reader = imageio.get_reader(path_to_image, mode='i')
+                self._reader = imageio.get_reader(image_resource, mode='i')
             self._volume = volume
         return self._reader
 
@@ -60,26 +76,29 @@ class GcsReader(ImageIOReader):
     def supports_url(cls):
         return True
 
-    def decode_gcs_url(self, url):
+    def __decode_gcs_url(self, url):
         p = urlparse(url)
-        path = p.path.split('/', 1)
-        bucket, file_path = p.netloc, path[1:][0]
-        return bucket, file_path
-
-    def download_blob(self, url):
+        file_path = p.path[1:] if p.path.startswith("/") else p.path
+        bucket_id = p.netloc
+        return bucket_id, file_path
+  
+    def __download_blob(self, url):
         if url:
             # Create client to access Google Cloud Storage.
-            client = storage.Client()
-            # Get bucket name, file path from URL.
-            bucket_id, file_path = self.decode_gcs_url(url)
-            # Get bucket.
-            bucket = client.bucket(bucket_id)
-            # Download blob object to local file path.
-            blob = bucket.blob(file_path)
-            local_file_path = os.path.basename(file_path)
-            blob.download_to_filename(local_file_path)
-            return local_file_path
-
-    @staticmethod
-    def get_settings():
-        return []
+            try:
+                client = storage.Client()
+                # Get bucket name, file path from URL.
+                bucket_id, file_path = self.__decode_gcs_url(url)
+                # Get bucket.
+                bucket = client.bucket(bucket_id)
+                # Download blob object to local file path.
+                blob = bucket.blob(file_path)
+                blob_bytes = io.BytesIO(blob.download_as_bytes())
+                return blob_bytes
+            except DefaultCredentialsError as e:
+               LOGGER.error(e.args[0])
+               return url
+            except NotFound as e:
+                # 404 error
+                LOGGER.error(e)
+                return url

--- a/cellprofiler_core/readers/gcs_reader.py
+++ b/cellprofiler_core/readers/gcs_reader.py
@@ -19,18 +19,23 @@ SUPPORTED_SCHEMES = {'gs'}
 
 class GcsReader(ImageIOReader):
     """
-    Reads images from bucket(s) in Google Cloud Storage via user's Application Default Credential (ADC).
-    Leverages ImageIOReader image processing methods.
+    Reads images from bucket(s) in Google Cloud Storage via user's Application
+    Default Credential (ADC).
+    
+    Once the file is downloaded from GCS, this reader leverages ImageIO Reader's
+    image loading methods.
 
     Prerequisites:
-    User has authenticated with Google Cloud Storage Application Default Credential (ADC) by running command,
-    `gcloud auth application-default login`,
-    or is running CellProfiler in an environment where this credential has already been configured for them
-    such as app.terra.bio or CloudShell.
+    User has authenticated with Google Cloud Storage Application Default Credential
+    (ADC) by running the command: "gcloud auth application-default login",
+    or is running CellProfiler in an environment where this credential has already
+    been configured for them such as app.terra.bio or CloudShell.
     """
 
-    reader_name = "GcsReader"
+    reader_name = "Google Cloud Storage"
     variable_revision_number = 1
+    supported_filetypes = SUPPORTED_EXTENSIONS.union(SUPPORTED_EXTENSIONS)
+    supported_schemes = SUPPORTED_SCHEMES
 
     @classmethod
     def supports_format(cls, image_file, allow_open=False, volume=False):

--- a/cellprofiler_core/readers/gcs_reader.py
+++ b/cellprofiler_core/readers/gcs_reader.py
@@ -1,4 +1,3 @@
-import os
 import io
 from urllib.parse import urlparse
 import logging
@@ -75,6 +74,10 @@ class GcsReader(ImageIOReader):
     @classmethod
     def supports_url(cls):
         return True
+
+    @staticmethod
+    def get_settings():
+        return []
 
     def __decode_gcs_url(self, url):
         p = urlparse(url)

--- a/cellprofiler_core/readers/gcs_reader.py
+++ b/cellprofiler_core/readers/gcs_reader.py
@@ -63,7 +63,7 @@ class GcsReader(ImageIOReader):
         return 4
 
     def get_reader(self, volume=False):
-        image_resource = self.__download_blob(self.file._url)
+        image_resource = self.__download_blob(self.file.url)
         if self._reader is None or volume != self._volume:
             if volume:
                 self._reader = imageio.get_reader(image_resource, mode='v')

--- a/cellprofiler_core/readers/imageio_reader.py
+++ b/cellprofiler_core/readers/imageio_reader.py
@@ -10,7 +10,7 @@ from ..reader import Reader
 SUPPORTED_EXTENSIONS = {'.png', '.bmp', '.jpeg', '.jpg', '.gif'}
 # bioformats returns 2 for these, imageio reader returns 3
 SEMI_SUPPORTED_EXTENSIONS = {'.tiff', '.tif', '.ome.tif', '.ome.tiff'}
-
+SUPPORTED_SCHEMES = {'file', 'http', 'https', 'ftp', 'ftps'}
 
 class ImageIOReader(Reader):
     """
@@ -127,13 +127,15 @@ class ImageIOReader(Reader):
 
         The volume parameter specifies whether the reader will need to return a 3D array.
         ."""
-        if image_file.url.lower().startswith("omero:"):
+        if image_file.scheme not in SUPPORTED_SCHEMES:
             return -1
         if image_file.file_extension in SUPPORTED_EXTENSIONS:
             return 2
         if image_file.full_extension in SEMI_SUPPORTED_EXTENSIONS:
             if config_read_typed(f"Reader.{ImageIOReader.reader_name}.read_tif", bool):
                 return 2
+            return 3
+
         return -1
 
     def close(self):

--- a/cellprofiler_core/readers/imageio_reader.py
+++ b/cellprofiler_core/readers/imageio_reader.py
@@ -20,6 +20,7 @@ class ImageIOReader(Reader):
     reader_name = "ImageIO"
     variable_revision_number = 1
     supported_filetypes = SUPPORTED_EXTENSIONS.union(SEMI_SUPPORTED_EXTENSIONS)
+    supported_schemes = SUPPORTED_SCHEMES
 
     def __init__(self, image_file):
         self.variable_revision_number = 1

--- a/cellprofiler_core/readers/ngff_reader.py
+++ b/cellprofiler_core/readers/ngff_reader.py
@@ -12,11 +12,10 @@ import re
 import logging
 from lxml import etree
 
-
-FORMAT_TESTER = re.compile(r"\.zarr([\\/]|$)", flags=re.IGNORECASE)
-
 LOGGER = logging.getLogger(__name__)
 
+FORMAT_TESTER = re.compile(r"\.zarr([\\/]|$)", flags=re.IGNORECASE)
+SUPPORTED_SCHEMES = {'file', 's3'}
 
 class NGFFReader(Reader):
     """
@@ -33,12 +32,12 @@ class NGFFReader(Reader):
     reader_name = "OME-NGFF"
     variable_revision_number = 1
     supported_filetypes = {'.zarr', '.ome.zarr'}
+    supported_schemes = SUPPORTED_SCHEMES
 
     # Reader cache maps a path to a tuple of (zarr_root_group, series_map).
     ZARR_READER_CACHE = {}
 
     def __init__(self, image_file):
-        self.variable_revision_number = 1
         super().__init__(image_file)
 
         self._reader = None

--- a/cellprofiler_core/utilities/pathname.py
+++ b/cellprofiler_core/utilities/pathname.py
@@ -1,9 +1,6 @@
-import os
 import pathlib
 import urllib
 import logging
-from importlib import import_module
-from importlib.util import find_spec
 
 from cellprofiler_core.constants.image import FILE_SCHEME, PASSTHROUGH_SCHEMES
 from cellprofiler_core.utilities.image import is_file_url
@@ -22,33 +19,11 @@ def pathname2url(path):
     # Produces CellProfiler's interpretation of a relative path URI.
     return FILE_SCHEME + urllib.request.pathname2url(path)
 
-
-def _handle_scheme(url):
-    lower_url = url.lower()
-    
-    if lower_url.startswith("gs"):
-        if find_spec("google.cloud") == None:
-            LOGGER.error(f"Unable to load google.cloud package (is it installed?)")
-            return None
-        
-        gcs_reader = import_module("cellprofiler_core.readers.gcs_reader")
-        parsed_url = urllib.parse.urlparse(lower_url)
-        cwd = os.getcwd()
-        local_filepath = "{}/{}".format(cwd, parsed_url.path)
-        # If image already downloaded, return local file path.
-        if os.path.exists(local_filepath):
-            return local_filepath
-        else:
-            reader = gcs_reader.GcsReader(url)
-            return reader.download_blob(url)
-    else:
-        return url
-
 def url2pathname(url):
     lower_url = url.lower()
 
     if any((lower_url.startswith(x) for x in PASSTHROUGH_SCHEMES)):
-        return _handle_scheme(url)
+        return url
 
     if is_file_url(url):
         return urllib.request.url2pathname(url[len(FILE_SCHEME):])

--- a/cellprofiler_core/worker/__init__.py
+++ b/cellprofiler_core/worker/__init__.py
@@ -21,6 +21,7 @@ the analysis worker runs three threads:
 import logging
 import os
 import sys
+import psutil
 
 import pkg_resources
 
@@ -157,12 +158,15 @@ if __name__ == "__main__":
     except:
         maxfd = 256
 
-    # this is a hacky solution to an annoying problem with vscode debugging
-    # we want to set breakpoints in the debugger
-    # but the debugger corresponds to one of the open file descriptors
-    # so closing it would cause the debugger to detach from the subprocess
+    proc = psutil.Process()
+
+    # This is a hacky solution to an annoying problem with vscode debugging:
+    # we want to set breakpoints in the debugger,
+    # but one of the file descriptors inhertited by the child
+    # corresponds to a TCP/IPv4 connection attached to the debugger,
+    # so closing it would cause the debugger to detach from the subprocess.
     # AFAICT the debugger fd is always 4, and is not associated with
-    # any device + inode combo (both 0)
+    # any device + inode combo (both 0, ie null), so
     # if we find that, skip closing fd 4, else close all
     try:
         stat = os.fstat(4)

--- a/cellprofiler_core/worker/__init__.py
+++ b/cellprofiler_core/worker/__init__.py
@@ -156,7 +156,24 @@ if __name__ == "__main__":
         maxfd = os.sysconf("SC_OPEN_MAX")
     except:
         maxfd = 256
-    os.closerange(3, maxfd)
+
+    # this is a hacky solution to an annoying problem with vscode debugging
+    # we want to set breakpoints in the debugger
+    # but the debugger corresponds to one of the open file descriptors
+    # so closing it would cause the debugger to detach from the subprocess
+    # AFAICT the debugger fd is always 4, and is not associated with
+    # any device + inode combo (both 0)
+    # if we find that, skip closing fd 4, else close all
+    try:
+        stat = os.fstat(4)
+        if stat.st_ino == 0 and stat.st_dev == 0:
+            os.close(3)
+            os.closerange(5, maxfd)
+        else:
+            os.closerange(3, maxfd)
+    except OSError:
+        os.closerange(3, maxfd)
+
     if not hasattr(sys, "frozen"):
         # In the development version, maybe the bioformats package is installed?
         # Add the root to the pythonpath

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         "scikit-image>=0.16.2",
         "scipy>=1.4.1",
         "zarr>=2.10",
+        "google-cloud-storage>=2.6.0",
     ],
     license="BSD",
     name="cellprofiler-core",


### PR DESCRIPTION
- add google-cloud-storage as core dependency
- add scheme (ie protocol) property to ImageFile
- check for supported schemes in all readers
- add supported schemes display in configure reader settings
- only favor GCS reader with 'gs' scheme (protocol)
- add some more granular error checking for GCS reader
- have gcs reader download as in-memory BytesIO rather than polluting local directory with permenant files (especially harmful for production build)
- remove gcs file downloading on pathname2url (again polluting local directory, and also redundant with image caching / gcs reader downloading)
- fix vs code debugging in analysis mode
- resolves #125 
- resolves CellProfiler/CellProfiler#4547