### PR TITLE
Fix volume reading

### DIFF
--- a/cellprofiler_core/readers/bioformats_reader.py
+++ b/cellprofiler_core/readers/bioformats_reader.py
@@ -104,7 +104,7 @@ class BioformatsReader(Reader):
             z_range = [z]
         if t is None:
             if z_len > 1:
-                t_range = 1
+                t_range = range(1)
             else:
                 t_range = range(bf_reader.getSizeT())
         else:


### PR DESCRIPTION
This PR fixes a bug where image previews for 3d images break when "Process as 3D" is enabled in NamesAndTypes.