### PR TITLE
Allow notes to have pipes without breaking pipeline loading

### DIFF
--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -580,7 +580,14 @@ class Pipeline:
             raise ValueError("Invalid format for attributes: %s" % attribute_string)
         # Fix for array dtypes which contain split separator
         attribute_string = attribute_string.replace("dtype='|S", "dtype='S")
-        attribute_strings = attribute_string[1:-1].split("|")
+        # 4674- sometimes notes have pipes
+        print(attribute_string)
+        prenote,note,postnote = re.split("(?P<note>\|notes:\[.*?\])",attribute_string)
+        print(prenote,note,postnote)
+        attribute_strings = prenote[1:].split("|")
+        attribute_strings += [note[1:]]
+        attribute_strings += postnote[1:-1].split("|") 
+        print(attribute_strings)
         variable_revision_number = None
         # make batch_state decodable from text pipelines
         # NOTE, MAGIC HERE: These variables are **necessary**, even though they

--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -581,13 +581,10 @@ class Pipeline:
         # Fix for array dtypes which contain split separator
         attribute_string = attribute_string.replace("dtype='|S", "dtype='S")
         # 4674- sometimes notes have pipes
-        print(attribute_string)
         prenote,note,postnote = re.split("(?P<note>\|notes:\[.*?\])",attribute_string)
-        print(prenote,note,postnote)
         attribute_strings = prenote[1:].split("|")
         attribute_strings += [note[1:]]
         attribute_strings += postnote[1:-1].split("|") 
-        print(attribute_strings)
         variable_revision_number = None
         # make batch_state decodable from text pipelines
         # NOTE, MAGIC HERE: These variables are **necessary**, even though they

--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -580,11 +580,15 @@ class Pipeline:
             raise ValueError("Invalid format for attributes: %s" % attribute_string)
         # Fix for array dtypes which contain split separator
         attribute_string = attribute_string.replace("dtype='|S", "dtype='S")
-        # 4674- sometimes notes have pipes
-        prenote,note,postnote = re.split("(?P<note>\|notes:\[.*?\]\|)",attribute_string)
-        attribute_strings = prenote[1:].split("|")
-        attribute_strings += [note[1:-1]]
-        attribute_strings += postnote[:-1].split("|") 
+        if len(re.split("(?P<note>\|notes:\[.*?\]\|)",attribute_string)) ==3:
+            # 4674- sometimes notes have pipes
+            prenote,note,postnote = re.split("(?P<note>\|notes:\[.*?\]\|)",attribute_string)
+            attribute_strings = prenote[1:].split("|")
+            attribute_strings += [note[1:-1]]
+            attribute_strings += postnote[:-1].split("|") 
+        else:
+            #old or weird pipeline without notes
+            attribute_strings = attribute_string[1:-1].split("|")
         variable_revision_number = None
         # make batch_state decodable from text pipelines
         # NOTE, MAGIC HERE: These variables are **necessary**, even though they

--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -581,10 +581,10 @@ class Pipeline:
         # Fix for array dtypes which contain split separator
         attribute_string = attribute_string.replace("dtype='|S", "dtype='S")
         # 4674- sometimes notes have pipes
-        prenote,note,postnote = re.split("(?P<note>\|notes:\[.*?\])",attribute_string)
+        prenote,note,postnote = re.split("(?P<note>\|notes:\[.*?\]\|)",attribute_string)
         attribute_strings = prenote[1:].split("|")
-        attribute_strings += [note[1:]]
-        attribute_strings += postnote[1:-1].split("|") 
+        attribute_strings += [note[1:-1]]
+        attribute_strings += postnote[:-1].split("|") 
         variable_revision_number = None
         # make batch_state decodable from text pipelines
         # NOTE, MAGIC HERE: These variables are **necessary**, even though they


### PR DESCRIPTION
Resolves https://github.com/CellProfiler/CellProfiler/issues/4674

I don't think tons of pipelines have pipes in the notes section, but we generally don't like to crash on loading. By pulling out the notes first with a regex rather than just doing the "|" splitting we do with the rest of the module reading, we should bypass this issue. 