### PR TITLE
Modify getters to check ImageFile

### DIFF
--- a/cellprofiler_core/pipeline/_image_plane.py
+++ b/cellprofiler_core/pipeline/_image_plane.py
@@ -4,7 +4,6 @@ import logging
 from cellprofiler_core.constants.measurement import RESERVED_METADATA_KEYS, \
     C_MONOCHROME, C_RGB, C_TILE, C_URL, \
     C_SERIES, C_CHANNEL, C_Z, C_T, C_INDEX, C_SERIES_NAME
-from cellprofiler_core.constants.modules.metadata import COL_INDEX
 from cellprofiler_core.pipeline import ImageFile
 
 logger = logging.getLogger(__name__)
@@ -112,7 +111,7 @@ class ImagePlane:
 
     @property
     def index(self):
-        return self.get_metadata(C_INDEX) or self.get_metadata(COL_INDEX)
+        return self.get_metadata(C_INDEX)
 
     @property
     def channel(self):

--- a/cellprofiler_core/pipeline/_image_plane.py
+++ b/cellprofiler_core/pipeline/_image_plane.py
@@ -4,6 +4,7 @@ import logging
 from cellprofiler_core.constants.measurement import RESERVED_METADATA_KEYS, \
     C_MONOCHROME, C_RGB, C_TILE, C_URL, \
     C_SERIES, C_CHANNEL, C_Z, C_T, C_INDEX, C_SERIES_NAME
+from cellprofiler_core.constants.modules.metadata import COL_INDEX
 from cellprofiler_core.pipeline import ImageFile
 
 logger = logging.getLogger(__name__)
@@ -103,31 +104,31 @@ class ImagePlane:
 
     @property
     def series(self):
-        return self._metadata_dict[C_SERIES]
+        return self.get_metadata(C_SERIES)
 
     @property
     def series_name(self):
-        return self._metadata_dict[C_SERIES_NAME]
+        return self.get_metadata(C_SERIES_NAME)
 
     @property
     def index(self):
-        return self._metadata_dict[C_INDEX]
+        return self.get_metadata(C_INDEX) or self.get_metadata(COL_INDEX)
 
     @property
     def channel(self):
-        return self._metadata_dict[C_CHANNEL]
+        return self.get_metadata(C_CHANNEL)
 
     @property
     def z(self):
-        return self._metadata_dict[C_Z]
+        return self.get_metadata(C_Z)
 
     @property
     def t(self):
-        return self._metadata_dict[C_T]
+        return self.get_metadata(C_T)
 
     @property
     def tile(self):
-        return self._metadata_dict[C_TILE]
+        return self.get_metadata(C_TILE)
 
     @property
     def multichannel(self):
@@ -149,10 +150,10 @@ class ImagePlane:
         return self._metadata_dict.items()
 
     def get_metadata(self, key):
-        if key in self._metadata_dict:
+        if key in self._metadata_dict and self._metadata_dict[key] != None:
             # Use Plane metadata
             return self._metadata_dict[key]
-        elif key in self.file.metadata:
+        elif key in self.file.metadata and self.file.metadata[key] != None:
             # Use File metadata
             return self.file.metadata[key]
         else:


### PR DESCRIPTION
This fixes a bug reported during the Imaging Platform Jamboree on 12/9/22.

Description:

> From the Translocation tutorial, once you load the pipeline with the right csv, the images load and appear correctly on the image set list, but if you try to start the test mode or analyze this erros apears (Encountered unrecoverable error in NamesAndTypes during startup: int() argument must be a string, a bytes-like object or a number, not 'NoneType')

What was going wrong:

In the referenced pipeline, Image extraction is not performed in the Images module, and metadata extraction is instead performed in the Metadata module.

During `modules/images -> Images.prepare_run()`, Image plane objects are created, providing only the image file, and no series/index information. In `pipeline/_image_plane -> ImagePlane.__init__()`, the image plane metadata dictionary initializes the `Series` and `Index` values to the default of `None` (even though the provided `ImageFile` has `Series` and `Frame` equal to 0.

Later, in `modules/namesandtypes -> NamesAndTypes.prepare_run()`, for each image plane, the `series` and `frame` values are queried and added to measurements. It then calls `self.aggregate_metadata()` which retrieves those values, which are lists of `None` objects, and compares them agains their expect data types, `COLTYPE_INTEGER`, causing an error.

This PR modifies the `pipeline/_image_plane -> ImagePlane`  getters so they will first query the given key in the `ImagePlane` object itself, and then fall back to the underlying `ImageFile`.