### PR TITLE
Remove deprecated numpy aliases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install numpy>=1.20.1
           # git clone https://github.com/CellProfiler/CellProfiler.git ~/cellprofiler
+          pip install --no-binary centrosome
           pip install -e .[test]
           # pip install -e ~/cellprofiler
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install numpy>=1.20.1
           # git clone https://github.com/CellProfiler/CellProfiler.git ~/cellprofiler
-          pip install centrosome --no-binary
+          pip install centrosome --no-binary :all:
           pip install -e .[test]
           # pip install -e ~/cellprofiler
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,6 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install numpy>=1.20.1
           # git clone https://github.com/CellProfiler/CellProfiler.git ~/cellprofiler
-          pip install --no-binary centrosome centrosome
           pip install -e .[test]
           # pip install -e ~/cellprofiler
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install numpy>=1.20.1
           # git clone https://github.com/CellProfiler/CellProfiler.git ~/cellprofiler
-          pip install centrosome --no-binary :all:
+          pip install --no-binary centrosome centrosome
           pip install -e .[test]
           # pip install -e ~/cellprofiler
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           pip install --upgrade pip setuptools wheel
           pip install numpy>=1.20.1
           # git clone https://github.com/CellProfiler/CellProfiler.git ~/cellprofiler
-          pip install --no-binary centrosome
+          pip install centrosome --no-binary
           pip install -e .[test]
           # pip install -e ~/cellprofiler
       - name: Test

--- a/cellprofiler_core/measurement/_measurements.py
+++ b/cellprofiler_core/measurement/_measurements.py
@@ -226,7 +226,7 @@ class Measurements:
 
         def fix_type(t):
             if t == "integer":
-                return numpy.int
+                return int
             if t.startswith("varchar"):
                 len = t.split("(")[1][:-1]
                 return numpy.dtype("a" + len)

--- a/cellprofiler_core/utilities/hdf5_dict.py
+++ b/cellprofiler_core/utilities/hdf5_dict.py
@@ -1182,7 +1182,7 @@ class HDF5FileList(object):
                     marker = 'REPLACE'
                     inserted = numpy.insert(existing_meta, insertion_indexes, marker).tolist()
                     inserted = [x if isinstance(x, numpy.ndarray) else blank_metadata for x in inserted]
-                    metadataset[:] = numpy.array(inserted, dtype=numpy.object)
+                    metadataset[:] = numpy.array(inserted, dtype=object)
                     # Now we insert the series name fields.
                     seriesnameset[:] = numpy.insert(existing_names, insertion_indexes, blank_names)
                 else:
@@ -1212,7 +1212,7 @@ class HDF5FileList(object):
                                                    maxshape=(None, )
                                                    )
                     md[:] = numpy.array([blank_metadata] * len(filenames),
-                                        dtype=numpy.object)
+                                        dtype=object)
             self.hdf5_file.flush()
         self.notify()
 

--- a/tests/modules/test_loaddata.py
+++ b/tests/modules/test_loaddata.py
@@ -245,7 +245,7 @@ def test_int_image_measurement():
     pipeline, module, filename = make_pipeline(csv_text)
     m = pipeline.run()
     data = m.get_current_image_measurement("Test_Measurement")
-    assert isinstance(data, numpy.integer), "data is type %s, not np.int" % (type(data))
+    assert isinstance(data, numpy.integer), "data is type %s, not int" % (type(data))
     assert data == 1
     os.remove(filename)
 


### PR DESCRIPTION
Some numpy aliases were deprecated in version 1.20, and those deprecations are [now expired in 1.24](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations). This PR removes deprecated numpy scalars.