### PR TITLE
Plugin system revisions

### DIFF
--- a/cellprofiler_core/constants/image.py
+++ b/cellprofiler_core/constants/image.py
@@ -152,9 +152,7 @@ SUB_NONE = "None"
 SUB_ALL = "All"
 SUB_SOME = "Some"
 FILE_SCHEME = "file:"
-#TODO: disabled until CellProfiler/CellProfiler#4684 is resolved
-# PASSTHROUGH_SCHEMES = ("http", "https", "ftp", "omero", "s3","gs")
-PASSTHROUGH_SCHEMES = ("http", "https", "ftp", "s3","gs")
+PASSTHROUGH_SCHEMES = ["http", "https", "ftp", "s3", "gs"]
 
 CT_GRAYSCALE = "Grayscale"
 CT_COLOR = "Color"

--- a/cellprofiler_core/reader/_reader.py
+++ b/cellprofiler_core/reader/_reader.py
@@ -1,3 +1,19 @@
+"""
+Readers are modular classes designed to read in image data. Like modules, readers can also be added as plugins
+using this template class. Place readers into the plugins directory to load them on startup.
+
+A typical reader plugin will add support for a specific file format or protocol.
+
+N.b. readers should not assume that cellprofiler (and by extension wx/the gui) is always available. In a
+headless environment cellprofiler_core may be installed alone.
+
+To add custom file URI schemas to CellProfiler, e.g. "omero:iid=123",
+append new entries to the list in cellprofiler_core/constants/image.py.
+This will allow the main file list to accept those URIs.
+
+If you need to add menu entries to the GUI, access cellprofiler.gui.plugins_menu and add
+entries to the container within. Further instructions are within that file.
+"""
 import uuid
 
 from abc import ABC, abstractmethod

--- a/cellprofiler_core/utilities/core/plugins.py
+++ b/cellprofiler_core/utilities/core/plugins.py
@@ -10,8 +10,8 @@ import traceback
 
 from cellprofiler_core.constants.modules import all_modules
 from cellprofiler_core.constants.modules import pymodules
-from cellprofiler_core.constants.reader import ALL_READERS, BAD_READERS
-from cellprofiler_core.preferences import get_plugin_directory
+from cellprofiler_core.constants.reader import ALL_READERS, BAD_READERS, AVAILABLE_READERS
+from cellprofiler_core.preferences import get_plugin_directory, config_read_typed
 from cellprofiler_core.module import Module
 from cellprofiler_core.reader import Reader
 
@@ -112,6 +112,9 @@ def add_reader(cp_reader):
                 inspect.getfile(cp_reader),
             )
         ALL_READERS[name] = cp_reader
+        enabled = config_read_typed(f'Reader.{name}.enabled', bool)
+        if enabled or enabled is None:
+            AVAILABLE_READERS[name] = cp_reader
     except Exception as e:
         LOGGER.warning("Failed to load %s", name, exc_info=True)
         if name in ALL_READERS:


### PR DESCRIPTION
This PR makes a few changes geared towards the plugin system:

- Made `cellprofiler_core.constants.image.PASSTHROUGH_SCHEMES` a list, meaning that reader plugins can append to it when adding compatibility for new schemas (rather than core needing to be updated to support each new format). It might be worth migrating 'gs' to this system if it's going to be a plugin.

- I've expanded docs on the reader template class. This includes references to features added in CellProfiler/CellProfiler#4794.

- I've fixed a bug where disabled (plugin?) readers were always registered as available even if they were disabled in the configuration dialog.



