### PR TITLE
Fix module shared_state dictionaries

### DIFF
--- a/cellprofiler_core/analysis/_runner.py
+++ b/cellprofiler_core/analysis/_runner.py
@@ -81,7 +81,7 @@ class Runner:
         self.initial_measurements_buf = initial_measurements_buf
 
         self.analysis_id = analysis_id
-        self.pipeline = pipeline.copy()
+        self.pipeline = pipeline.copy(preserve_module_state=True)
         self.event_listener = event_listener
 
         self.interface_work_cv = threading.Condition()

--- a/cellprofiler_core/analysis/_runner.py
+++ b/cellprofiler_core/analysis/_runner.py
@@ -386,6 +386,9 @@ class Runner:
                         self.shared_dicts = finished_req.shared_dicts
                         waiting_for_first_imageset = False
                         assert len(self.shared_dicts) == len(self.pipeline.modules())
+                        for worker_dict, module in zip(self.shared_dicts, self.pipeline.modules()):
+                            # Apply those imported states to the master pipeline
+                            module.get_dictionary().update(worker_dict)
                         # if we had jobs waiting for the first image set to finish,
                         # queue them now that the shared state is available.
                         for job in job_groups:

--- a/cellprofiler_core/pipeline/_pipeline.py
+++ b/cellprofiler_core/pipeline/_pipeline.py
@@ -186,13 +186,16 @@ class Pipeline:
     def needs_headless_extraction(self):
         return self.__needs_headless_extraction
 
-    def copy(self, save_image_plane_details=True):
+    def copy(self, save_image_plane_details=True, preserve_module_state=False):
         """Create a copy of the pipeline modules and settings"""
         fd = io.StringIO()
         self.dump(fd, save_image_plane_details=save_image_plane_details)
         pipeline = Pipeline()
         fd.seek(0)
         pipeline.load(fd)
+        if preserve_module_state:
+            for orig_module, copied_module in zip(self.modules(), pipeline.modules()):
+                copied_module.shared_state = orig_module.shared_state.copy()
         return pipeline
 
     def settings_hash(self, until_module=None, as_string=False):


### PR DESCRIPTION
CellProfiler modules have a `shared_state` property (accessed from `module.get_dictionary()`) designed to allow the module to pass values to itself without using measurements. This is used by a number of modules, typically to keep track of intermediates between image sets e.g. projection, illum or to cache complex objects between module runs. This avoids the need to store such info in the main measurements hdf5 file.

In general the modules that use it only add entries to the module state during the `prepare_group` phase (which is run by each worker in analysis mode). Currently anything added to the state during `prepare_run` is 'forgotten' when starting up analysis mode. This seemed odd since there is a dedicated zmq messaging Request/Reply (`SharedDictionary`) which is supposed to transmit the main program's module state into the workers when analysis starts. In practice this response is always an empty dictionary for each module.

I dug into this and it turns out the issue is that we run `.copy()` on the pipeline when starting up the analysis runner. As this isn't a deep copy we end up blanking the module dicts in the runner's version of the pipeline, therein meaning that any worker requests cannot get the state dictionaries. A simple tweak fixes this and means that anything added to module state before running (i.e. in `m.prepare_run`) is now transmitted properly into the workers as intended.

This shouldn't immediately change any existing functionality, I think people have been coding around this bug for many years by pushing functionality into `m.prepare_group`, but this is not always acceptable. It's possible this issue came about in the transition to CP4 and just hasn't been noticed.

The fix here does mean that we can replace the (admittedly terrible) system that I'd added to ExportToDatabase in cellprofiler/cellprofiler#4396 - those temporary measurements which have caused some other bugs were a workaround for this issue.

Testing this probably isn't trivial since it's not a well-used function, but to do so:
- Call `self.get_dictionary()` and add entries within a module's `prepare_run` method.
- Print results of `self.get_dictionary()` in the module's `run` method.
- Without the PR the entries will be absent in the workers' version of the dict.
- With the PR the entries should have been transmitted into the workers, so they'll show up as intended.

