### PR TITLE
Refactor Choice to return enum from value properly

### DIFF
--- a/cellprofiler_core/setting/choice/_choice.py
+++ b/cellprofiler_core/setting/choice/_choice.py
@@ -45,7 +45,7 @@ class Choice(Setting):
     
     def get_enum_member(self):
         """The enum value for the current setting"""
-        return self.__enum._value2member_map_[self.value]
+        return self.__enum(self.value)
     
     enum_member = property(__internal_get_enum_member)
 

--- a/cellprofiler_core/setting/choice/_choice.py
+++ b/cellprofiler_core/setting/choice/_choice.py
@@ -45,7 +45,10 @@ class Choice(Setting):
     
     def get_enum_member(self):
         """The enum value for the current setting"""
-        return self.__enum(self.value)
+        if self.__enum:
+            return self.__enum(self.value)
+        else:
+            raise ValueError("Choice setting is not an enum")
     
     enum_member = property(__internal_get_enum_member)
 


### PR DESCRIPTION
getting members from enums is supported by both name and value, no need to use internal `_value2member_map_`