### PR TITLE
Fix worker halting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,8 @@ jobs:
         env:
           LC_ALL: "en_US.UTF-8"
         run: |
-          brew install mysql
+          brew install mysql@8.0
+          brew link mysql@8.0 --force
           mysql.server start
           mysql --host=$CP_MYSQL_TEST_HOST --user=$CP_MYSQL_TEST_USER --execute="CREATE DATABASE $CP_MYSQL_TEST_DB;" --skip-password
       - name: Installation
@@ -51,7 +52,7 @@ jobs:
           |
           pip install pyinstaller
           pip install --upgrade pip setuptools wheel
-          pip install numpy>=1.20.1
+          pip install "numpy>=1.20.1,<2" "Cython<3"
           # git clone https://github.com/CellProfiler/CellProfiler.git ~/cellprofiler
           pip install -e .[test]
           # pip install -e ~/cellprofiler

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [macos-11]
+        os: [macos-13]
         python-version: [ 3.8, 3.9 ]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/cellprofiler_core/analysis/_runner.py
+++ b/cellprofiler_core/analysis/_runner.py
@@ -102,7 +102,7 @@ class Runner:
         # should have jobserver() call load_measurements_from_buffer() rather
         # than interface() doing so.  Currently, passing measurements in this
         # way seems like it might be buggy:
-        # http://code.google.com/p/h5py/issues/detail?id=244
+        # https://github.com/h5py/h5py/issues/244
         self.received_measurements_queue = queue.Queue(maxsize=10)
 
         self.shared_dicts = None

--- a/cellprofiler_core/utilities/zmq/__init__.py
+++ b/cellprofiler_core/utilities/zmq/__init__.py
@@ -17,6 +17,7 @@ from cellprofiler_core.utilities.zmq.communicable.request import (
     LockStatusRequest,
     Request,
 )
+from ._event import PollTimeoutException
 
 NOTIFY_SOCKET_ADDR = "inproc://BoundaryNotifications"
 SD_KEY_DICT = "__keydict__"

--- a/cellprofiler_core/utilities/zmq/_event.py
+++ b/cellprofiler_core/utilities/zmq/_event.py
@@ -1,0 +1,4 @@
+class PollTimeoutException(Exception):
+    """Exception issued by a timeout from polling"""
+
+    pass


### PR DESCRIPTION
- add retry for workers failing to send MeasurementsReport, so they don't hang indefinitely
- add safeguard around post group run