### PR TITLE
Fix re-coding of Windows paths

### DIFF
--- a/cellprofiler_core/measurement/_measurements.py
+++ b/cellprofiler_core/measurement/_measurements.py
@@ -1458,11 +1458,16 @@ class Measurements:
         if not self.has_feature(EXPERIMENT, M_PATH_MAPPINGS,):
             return url
         d = json.loads(self.get_experiment_measurement(M_PATH_MAPPINGS))
-        full_name = os_url2pathname(url[5:])
+        if url[:8] =="file:///": #windows encoded paths
+            full_name = os_url2pathname(url[8:])
+        else:
+            full_name = os_url2pathname(url[5:])
         full_name_c = full_name if d[K_CASE_SENSITIVE] else full_name.lower()
         if d[K_LOCAL_SEPARATOR] != os.path.sep:
             full_name = full_name.replace(d[K_LOCAL_SEPARATOR], os.path.sep)
         for local_directory, remote_directory in d[K_PATH_MAPPINGS]:
+            if d[K_LOCAL_SEPARATOR] != os.path.sep:
+                local_directory = local_directory.replace(d[K_LOCAL_SEPARATOR], os.path.sep)
             if d[K_CASE_SENSITIVE]:
                 if full_name_c.startswith(local_directory):
                     full_name = remote_directory + full_name[len(local_directory) :]


### PR DESCRIPTION
Related to  https://github.com/CellProfiler/CellProfiler/issues/4977 

Path adjustment 

Path adjustment correctly working when tested on:

- [x] Windows to posix
- [x] Posix to posix
- [ ] Windows to Windows
- [ ] Posix to Windows

Also:
- [x] Existing tests passing
- [ ] New tests either written or consciously decided not needed

I am not giving this a resolves tag at the moment, because as I mentioned in the issue body of that issue, I think we should think about an entirely different set of changes to make sure this works in CP5 - at least at the moment, I'm not convinced storing the Java objects inside the batch file is the way to go (in fact, since CP5 is java-optional, it kinda can't be, right?); if we want to tag the current issue closed though when we pull this, and make a new issue for the bigger picture consideration of CP5 batchfiles, also fine with that, just want to make sure that doesn't fall off the radar.